### PR TITLE
feat: change access endpoints to mach gateway

### DIFF
--- a/Backend.API/Features/Accesses/AccessesController.cs
+++ b/Backend.API/Features/Accesses/AccessesController.cs
@@ -8,34 +8,19 @@ public class AccessesController(IAccessesService accessService) : ControllerBase
 {
     private readonly IAccessesService _accessService = accessService;
 
-    [HttpPost("entry")]
-    public async Task<ActionResult<AccessDto>> RegisterEntry([FromBody] CreateAccessDto dto)
+    [HttpGet]
+    public async Task<ActionResult<IEnumerable<AccessDto>>> GetAccesses()
     {
-        try
-        {
-            var access = await _accessService.RegisterEntryAsync(dto);
-            return StatusCode(StatusCodes.Status201Created, access);
-        }
-        catch (KeyNotFoundException ex)
-        {
-            return NotFound(new { error = ex.Message });
-        }
-        catch (InvalidOperationException ex)
-        {
-            return Conflict(new { error = ex.Message });
-        }
-        catch (Exception)
-        {
-            return StatusCode(StatusCodes.Status500InternalServerError, new { error = "Ocorreu um erro interno no servidor." });
-        }
+        var accesses = await _accessService.GetAccessesAsync();
+        return Ok(accesses);
     }
 
-    [HttpPost("exit")]
-    public async Task<ActionResult<AccessDto>> RegisterExit([FromBody] CreateAccessDto dto)
+    [HttpPost]
+    public async Task<ActionResult<AccessDto>> RegisterAccess([FromBody] CreateAccessDto dto)
     {
         try
         {
-            var access = await _accessService.RegisterExitAsync(dto);
+            var access = await _accessService.RegisterAccessAsync(dto);
             return StatusCode(StatusCodes.Status201Created, access);
         }
         catch (KeyNotFoundException ex)

--- a/Backend.API/Features/Accesses/AccessesService.cs
+++ b/Backend.API/Features/Accesses/AccessesService.cs
@@ -7,34 +7,47 @@ namespace Backend.Features.Accesses;
 
 public interface IAccessesService
 {
-    Task<AccessDto> RegisterEntryAsync(CreateAccessDto dto);
-    Task<AccessDto> RegisterExitAsync(CreateAccessDto dto);
+    Task<IEnumerable<AccessDto>> GetAccessesAsync();
+    Task<AccessDto> RegisterAccessAsync(CreateAccessDto dto);
 }
 
 public class AccessesService(AppDbContext db) : IAccessesService
 {
     private readonly AppDbContext _db = db;
 
-    public async Task<AccessDto> RegisterEntryAsync(CreateAccessDto dto)
+    public async Task<IEnumerable<AccessDto>> GetAccessesAsync()
     {
+        var accesses = await _db.Accesses
+            .OrderByDescending(a => a.Timestamp)
+            .ToListAsync();
 
-        var tag = await GetActiveTagAsync(dto.TagId);
+        return accesses.Select(AccessDto.FromModel);
+    }
 
+    public async Task<AccessDto> RegisterAccessAsync(CreateAccessDto dto)
+    {
+        var tag = await GetActiveTagAsync(dto.Tid, dto.Epc);
 
         var lastAccess = await _db.Accesses
             .Where(a => a.TagId == tag.TagId)
             .OrderByDescending(a => a.Timestamp)
             .FirstOrDefaultAsync();
 
-        if (lastAccess != null && lastAccess.Type == AccessType.Entry)
-            throw new InvalidOperationException("Não é possível registrar a entrada: o veículo já está no estacionamento.");
-
+        if (dto.Entrance)
+        {
+            if (lastAccess != null && lastAccess.Type == AccessType.Entry)
+                throw new InvalidOperationException("Não é possível registrar a entrada: o veículo já está no estacionamento.");
+        }
+        else
+        {
+            if (lastAccess == null || lastAccess.Type == AccessType.Exit)
+                throw new InvalidOperationException("Não é possível registrar a saída: o veículo não está no estacionamento.");
+        }
 
         var access = new Access
         {
             TagId = tag.TagId,
-
-            Type = AccessType.Entry,
+            Type = dto.Entrance ? AccessType.Entry : AccessType.Exit,
             Tag = tag,
             Timestamp = DateTime.UtcNow
         };
@@ -45,40 +58,11 @@ public class AccessesService(AppDbContext db) : IAccessesService
         return AccessDto.FromModel(access);
     }
 
-    public async Task<AccessDto> RegisterExitAsync(CreateAccessDto dto)
-    {
-
-        var tag = await GetActiveTagAsync(dto.TagId);
-
-
-        var lastAccess = await _db.Accesses
-            .Where(a => a.TagId == tag.TagId)
-            .OrderByDescending(a => a.Timestamp)
-            .FirstOrDefaultAsync();
-
-        if (lastAccess == null || lastAccess.Type == AccessType.Exit)
-            throw new InvalidOperationException("Não é possível registrar a saída: o veículo não está no estacionamento.");
-
-
-        var access = new Access
-        {
-            TagId = tag.TagId,
-            Type = AccessType.Exit,
-            Tag = tag,
-            Timestamp = DateTime.UtcNow
-        };
-
-        await _db.Accesses.AddAsync(access);
-        await _db.SaveChangesAsync();
-
-        return AccessDto.FromModel(access);
-    }
-
-    private async Task<Tag> GetActiveTagAsync(Guid tagId)
+    private async Task<Tag> GetActiveTagAsync(string tid, string epc)
     {
         var tag = await _db.Tags
             .Include(t => t.Vehicle)
-            .FirstOrDefaultAsync(t => t.TagId == tagId)
+            .FirstOrDefaultAsync(t => t.Tid == tid && t.Epc == epc)
             ?? throw new KeyNotFoundException("A tag informada não existe.");
 
         if (tag.Status != TagStatus.IN_USE)

--- a/Backend.API/Features/Accesses/Dtos/CreateAccessDto.cs
+++ b/Backend.API/Features/Accesses/Dtos/CreateAccessDto.cs
@@ -1,9 +1,8 @@
-using System.ComponentModel.DataAnnotations;
-
 namespace Backend.Features.Accesses;
 
 public class CreateAccessDto
 {
-    [Required(ErrorMessage = "TagId is required.")]
-    public required Guid TagId { get; set; }
+    public required string Tid { get; init; }
+    public required string Epc { get; init; }
+    public bool Entrance { get; init; }
 }

--- a/Backend.Tests.Integration/Features/Accesses/AccessesControllerTests.cs
+++ b/Backend.Tests.Integration/Features/Accesses/AccessesControllerTests.cs
@@ -24,7 +24,7 @@ public class AccessesControllerTests(CustomWebApplicationFactory factory) : ICla
 
     public Task DisposeAsync() => Task.CompletedTask;
 
-    private async Task<Guid> SeedVehicleAndTagAsync(TagStatus status = TagStatus.IN_USE)
+    private async Task<(Guid TagId, string Tid, string Epc)> SeedVehicleAndTagAsync(TagStatus status = TagStatus.IN_USE)
     {
         using var scope = _scopeFactory.CreateScope();
         var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
@@ -32,13 +32,15 @@ public class AccessesControllerTests(CustomWebApplicationFactory factory) : ICla
         var user = new User { Name = "Test", Email = $"test_{Guid.NewGuid()}@example.com", PasswordHash = "hash", Role = UserRole.Customer };
         db.Users.Add(user);
 
-        var tag = new Tag { Status = status, Epc = $"EPC-{Guid.NewGuid()}", Tid = $"TID-{Guid.NewGuid()}" };
+        var tid = $"TID-{Guid.NewGuid()}";
+        var epc = $"EPC-{Guid.NewGuid()}";
+        var tag = new Tag { Status = status, Epc = epc, Tid = tid };
         db.Tags.Add(tag);
 
         db.Vehicles.Add(new Vehicle { UserId = user.UserId, TagId = tag.TagId, Plate = $"TST{Guid.NewGuid().ToString()[..4].ToUpper()}", Brand = "VW", Model = "Gol" });
 
         await db.SaveChangesAsync();
-        return tag.TagId;
+        return (tag.TagId, tid, epc);
     }
 
     private async Task SeedAccessAsync(Guid tagId, AccessType type)
@@ -60,50 +62,42 @@ public class AccessesControllerTests(CustomWebApplicationFactory factory) : ICla
     }
 
     [Fact]
-    public async Task PostEntry_WithValidTag_ReturnsCreated()
+    public async Task PostAccess_Entry_WithValidTag_ReturnsCreated()
     {
-        var tagId = await SeedVehicleAndTagAsync();
-        var payload = new CreateAccessDto { TagId = tagId };
+        var (_, tid, epc) = await SeedVehicleAndTagAsync();
+        var payload = new CreateAccessDto { Tid = tid, Epc = epc, Entrance = true };
 
-
-        var response = await _client.PostAsync("/api/accesses/entry", JsonContent.Create(payload, options: CustomWebApplicationFactory.JsonOptions));
-
+        var response = await _client.PostAsync("/api/accesses", JsonContent.Create(payload, options: CustomWebApplicationFactory.JsonOptions));
 
         Assert.Equal(HttpStatusCode.Created, response.StatusCode);
         var result = await response.Content.ReadFromJsonAsync<AccessDto>(CustomWebApplicationFactory.JsonOptions);
         Assert.NotNull(result);
-        Assert.Equal(tagId, result.TagId);
         Assert.Equal(AccessType.Entry, result.Type);
     }
 
     [Fact]
-    public async Task PostEntry_WhenAlreadyInside_ReturnsConflict()
+    public async Task PostAccess_Entry_WhenAlreadyInside_ReturnsConflict()
     {
-        var tagId = await SeedVehicleAndTagAsync();
-        var payload = new CreateAccessDto { TagId = tagId };
+        var (_, tid, epc) = await SeedVehicleAndTagAsync();
+        var payload = new CreateAccessDto { Tid = tid, Epc = epc, Entrance = true };
 
+        await _client.PostAsync("/api/accesses", JsonContent.Create(payload, options: CustomWebApplicationFactory.JsonOptions));
 
-        await _client.PostAsync("/api/accesses/entry", JsonContent.Create(payload, options: CustomWebApplicationFactory.JsonOptions));
-
-
-        var response = await _client.PostAsync("/api/accesses/entry", JsonContent.Create(payload, options: CustomWebApplicationFactory.JsonOptions));
-
+        var response = await _client.PostAsync("/api/accesses", JsonContent.Create(payload, options: CustomWebApplicationFactory.JsonOptions));
 
         Assert.Equal(HttpStatusCode.Conflict, response.StatusCode);
     }
 
     [Fact]
-    public async Task PostExit_WhenSuccessfullyEntered_ReturnsCreated()
+    public async Task PostAccess_Exit_WhenSuccessfullyEntered_ReturnsCreated()
     {
-        var tagId = await SeedVehicleAndTagAsync();
-        var payload = new CreateAccessDto { TagId = tagId };
+        var (_, tid, epc) = await SeedVehicleAndTagAsync();
+        var entryPayload = new CreateAccessDto { Tid = tid, Epc = epc, Entrance = true };
+        var exitPayload = new CreateAccessDto { Tid = tid, Epc = epc, Entrance = false };
 
+        await _client.PostAsync("/api/accesses", JsonContent.Create(entryPayload, options: CustomWebApplicationFactory.JsonOptions));
 
-        await _client.PostAsync("/api/accesses/entry", JsonContent.Create(payload, options: CustomWebApplicationFactory.JsonOptions));
-
-
-        var response = await _client.PostAsync("/api/accesses/exit", JsonContent.Create(payload, options: CustomWebApplicationFactory.JsonOptions));
-
+        var response = await _client.PostAsync("/api/accesses", JsonContent.Create(exitPayload, options: CustomWebApplicationFactory.JsonOptions));
 
         Assert.Equal(HttpStatusCode.Created, response.StatusCode);
         var result = await response.Content.ReadFromJsonAsync<AccessDto>(CustomWebApplicationFactory.JsonOptions);
@@ -111,53 +105,45 @@ public class AccessesControllerTests(CustomWebApplicationFactory factory) : ICla
     }
 
     [Fact]
-    public async Task PostExit_WithoutPriorEntry_ReturnsConflict()
+    public async Task PostAccess_Exit_WithoutPriorEntry_ReturnsConflict()
     {
-        var tagId = await SeedVehicleAndTagAsync();
-        var payload = new CreateAccessDto { TagId = tagId };
+        var (_, tid, epc) = await SeedVehicleAndTagAsync();
+        var payload = new CreateAccessDto { Tid = tid, Epc = epc, Entrance = false };
 
-
-        var response = await _client.PostAsync("/api/accesses/exit", JsonContent.Create(payload, options: CustomWebApplicationFactory.JsonOptions));
-
+        var response = await _client.PostAsync("/api/accesses", JsonContent.Create(payload, options: CustomWebApplicationFactory.JsonOptions));
 
         Assert.Equal(HttpStatusCode.Conflict, response.StatusCode);
     }
 
     [Fact]
-    public async Task PostEntry_WithNonExistentTag_ReturnsNotFound()
+    public async Task PostAccess_WithNonExistentTag_ReturnsNotFound()
     {
-        var payload = new CreateAccessDto { TagId = Guid.NewGuid() };
+        var payload = new CreateAccessDto { Tid = "NONEXISTENT-TID", Epc = "NONEXISTENT-EPC", Entrance = true };
 
-
-        var response = await _client.PostAsync("/api/accesses/entry", JsonContent.Create(payload, options: CustomWebApplicationFactory.JsonOptions));
-
+        var response = await _client.PostAsync("/api/accesses", JsonContent.Create(payload, options: CustomWebApplicationFactory.JsonOptions));
 
         Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
     }
 
     [Fact]
-    public async Task PostEntry_WithInactiveTag_ReturnsConflict()
+    public async Task PostAccess_Entry_WithInactiveTag_ReturnsConflict()
     {
-        var tagId = await SeedVehicleAndTagAsync(TagStatus.INACTIVE);
-        var payload = new CreateAccessDto { TagId = tagId };
+        var (_, tid, epc) = await SeedVehicleAndTagAsync(TagStatus.INACTIVE);
+        var payload = new CreateAccessDto { Tid = tid, Epc = epc, Entrance = true };
 
-
-        var response = await _client.PostAsync("/api/accesses/entry", JsonContent.Create(payload, options: CustomWebApplicationFactory.JsonOptions));
-
+        var response = await _client.PostAsync("/api/accesses", JsonContent.Create(payload, options: CustomWebApplicationFactory.JsonOptions));
 
         Assert.Equal(HttpStatusCode.Conflict, response.StatusCode);
     }
 
     [Fact]
-    public async Task PostExit_WithInactiveTag_ReturnsConflict()
+    public async Task PostAccess_Exit_WithInactiveTag_ReturnsConflict()
     {
-        var tagId = await SeedVehicleAndTagAsync(TagStatus.INACTIVE);
+        var (tagId, tid, epc) = await SeedVehicleAndTagAsync(TagStatus.INACTIVE);
         await SeedAccessAsync(tagId, AccessType.Entry);
-        var payload = new CreateAccessDto { TagId = tagId };
+        var payload = new CreateAccessDto { Tid = tid, Epc = epc, Entrance = false };
 
-
-        var response = await _client.PostAsync("/api/accesses/exit", JsonContent.Create(payload, options: CustomWebApplicationFactory.JsonOptions));
-
+        var response = await _client.PostAsync("/api/accesses", JsonContent.Create(payload, options: CustomWebApplicationFactory.JsonOptions));
 
         Assert.Equal(HttpStatusCode.Conflict, response.StatusCode);
     }

--- a/Backend.Tests.Integration/Features/Accesses/AccessesControllerTests.cs
+++ b/Backend.Tests.Integration/Features/Accesses/AccessesControllerTests.cs
@@ -147,4 +147,30 @@ public class AccessesControllerTests(CustomWebApplicationFactory factory) : ICla
 
         Assert.Equal(HttpStatusCode.Conflict, response.StatusCode);
     }
+
+    [Fact]
+    public async Task GetAccesses_WhenEmpty_ReturnsOkWithEmptyList()
+    {
+        var response = await _client.GetAsync("/api/accesses");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var result = await response.Content.ReadFromJsonAsync<List<AccessDto>>(CustomWebApplicationFactory.JsonOptions);
+        Assert.NotNull(result);
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task GetAccesses_WithSeededData_ReturnsAllAccesses()
+    {
+        var (tagId, _, _) = await SeedVehicleAndTagAsync();
+        await SeedAccessAsync(tagId, AccessType.Entry);
+        await SeedAccessAsync(tagId, AccessType.Exit);
+
+        var response = await _client.GetAsync("/api/accesses");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var result = await response.Content.ReadFromJsonAsync<List<AccessDto>>(CustomWebApplicationFactory.JsonOptions);
+        Assert.NotNull(result);
+        Assert.Equal(2, result.Count);
+    }
 }

--- a/Backend.Tests.Unit/Features/Accesses/AccessesControllerTests.cs
+++ b/Backend.Tests.Unit/Features/Accesses/AccessesControllerTests.cs
@@ -7,21 +7,21 @@ namespace Backend.Tests.Unit.Features.Accesses;
 
 public class AccessesControllerTests
 {
+    private static CreateAccessDto MakeDto(bool entrance = true) =>
+        new() { Tid = "TID-001", Epc = "EPC-001", Entrance = entrance };
+
     [Fact]
-    public async Task RegisterEntry_WhenSuccess_ReturnsCreated()
+    public async Task RegisterAccess_Entry_WhenSuccess_ReturnsCreated()
     {
-        var tagId = Guid.NewGuid();
-        var dto = new CreateAccessDto { TagId = tagId };
-        var expected = new AccessDto { AccessId = Guid.NewGuid(), TagId = tagId, Type = AccessType.Entry, Timestamp = DateTime.UtcNow };
+        var dto = MakeDto(entrance: true);
+        var expected = new AccessDto { AccessId = Guid.NewGuid(), TagId = Guid.NewGuid(), Type = AccessType.Entry, Timestamp = DateTime.UtcNow };
 
         var service = Substitute.For<IAccessesService>();
-        service.RegisterEntryAsync(dto).Returns(expected);
+        service.RegisterAccessAsync(dto).Returns(expected);
 
         var controller = new AccessesController(service);
 
-
-        var result = await controller.RegisterEntry(dto);
-
+        var result = await controller.RegisterAccess(dto);
 
         var createdResult = Assert.IsType<ObjectResult>(result.Result);
         Assert.Equal(201, createdResult.StatusCode);
@@ -29,49 +29,43 @@ public class AccessesControllerTests
     }
 
     [Fact]
-    public async Task RegisterEntry_WhenTagNotFound_ReturnsNotFound()
+    public async Task RegisterAccess_WhenTagNotFound_ReturnsNotFound()
     {
-        var dto = new CreateAccessDto { TagId = Guid.NewGuid() };
+        var dto = MakeDto();
         var service = Substitute.For<IAccessesService>();
-        service.RegisterEntryAsync(dto).ThrowsAsync(new KeyNotFoundException("Tag not found"));
+        service.RegisterAccessAsync(dto).ThrowsAsync(new KeyNotFoundException("Tag not found"));
 
         var controller = new AccessesController(service);
 
-
-        var result = await controller.RegisterEntry(dto);
-
+        var result = await controller.RegisterAccess(dto);
 
         Assert.IsType<NotFoundObjectResult>(result.Result);
     }
 
     [Fact]
-    public async Task RegisterEntry_WhenTagInactive_ReturnsConflict()
+    public async Task RegisterAccess_WhenTagInactive_ReturnsConflict()
     {
-        var dto = new CreateAccessDto { TagId = Guid.NewGuid() };
+        var dto = MakeDto();
         var service = Substitute.For<IAccessesService>();
-        service.RegisterEntryAsync(dto).ThrowsAsync(new InvalidOperationException("Tag inactive"));
+        service.RegisterAccessAsync(dto).ThrowsAsync(new InvalidOperationException("Tag inactive"));
 
         var controller = new AccessesController(service);
 
-
-        var result = await controller.RegisterEntry(dto);
-
+        var result = await controller.RegisterAccess(dto);
 
         Assert.IsType<ConflictObjectResult>(result.Result);
     }
 
     [Fact]
-    public async Task RegisterExit_WhenAlreadyOutside_ReturnsConflict()
+    public async Task RegisterAccess_Exit_WhenAlreadyOutside_ReturnsConflict()
     {
-        var dto = new CreateAccessDto { TagId = Guid.NewGuid() };
+        var dto = MakeDto(entrance: false);
         var service = Substitute.For<IAccessesService>();
-        service.RegisterExitAsync(dto).ThrowsAsync(new InvalidOperationException("Already outside"));
+        service.RegisterAccessAsync(dto).ThrowsAsync(new InvalidOperationException("Already outside"));
 
         var controller = new AccessesController(service);
 
-
-        var result = await controller.RegisterExit(dto);
-
+        var result = await controller.RegisterAccess(dto);
 
         Assert.IsType<ConflictObjectResult>(result.Result);
     }


### PR DESCRIPTION
1. Unifica os endpoints POST /entry e POST /exit em um único POST /api/accesses, recebendo o campo entrance (boolean) para determinar o tipo de acesso
2. Substitui a identificação da tag por TagId (Guid) para Tid + Epc (strings), alinhando com o contrato do gateway RFID
3. Adiciona GET /api/accesses retornando todos os acessos ordenados do mais recente para o mais antigo
4. Adiciona testes para os endpoints adicionados