### PR TITLE
feat: auth logic on all features

### DIFF
--- a/Backend.API/Features/Dashboard/DashboardController.cs
+++ b/Backend.API/Features/Dashboard/DashboardController.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Mvc;
 
@@ -5,6 +6,7 @@ namespace Backend.Features.Dashboard;
 
 [ApiController]
 [Route("api/dashboard")]
+[Authorize(Roles = "Admin")]
 public class DashboardController(IDashboardService dashboardService) : ControllerBase
 {
     private readonly IDashboardService _dashboardService = dashboardService;

--- a/Backend.API/Features/ParkingPrices/ParkingPricesController.cs
+++ b/Backend.API/Features/ParkingPrices/ParkingPricesController.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Backend.Features.ParkingPrices;
@@ -30,6 +31,7 @@ public class ParkingPricesController(IParkingPricesService parkingPricesService)
     }
 
     [HttpPost]
+    [Authorize(Roles = "Admin")]
     public async Task<ActionResult<ParkingPricesDto>> CreateParkingPrice(CreateParkingPriceDto dto)
     {
         var parkingPrice = await _parkingPricesService.CreateParkingPriceAsync(dto);
@@ -37,6 +39,7 @@ public class ParkingPricesController(IParkingPricesService parkingPricesService)
     }
 
     [HttpPatch("{id}")]
+    [Authorize(Roles = "Admin")]
     public async Task<ActionResult<ParkingPricesDto>> UpdateParkingPrice(Guid id, UpdateParkingPriceDto dto)
     {
         try
@@ -51,6 +54,7 @@ public class ParkingPricesController(IParkingPricesService parkingPricesService)
     }
 
     [HttpDelete("{id}")]
+    [Authorize(Roles = "Admin")]
     public async Task<IActionResult> DeleteParkingPrice(Guid id)
     {
         try

--- a/Backend.API/Features/Tags/TagController.cs
+++ b/Backend.API/Features/Tags/TagController.cs
@@ -1,9 +1,11 @@
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Backend.Features.Tags;
 
 [ApiController]
 [Route("api/tags")]
+[Authorize(Roles = "Admin")]
 public class TagController(ITagService tagService) : ControllerBase
 {
     private readonly ITagService _tagService = tagService;

--- a/Backend.API/Features/Users/UsersController.cs
+++ b/Backend.API/Features/Users/UsersController.cs
@@ -1,14 +1,18 @@
+using Backend.Features.Auth;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Backend.Features.Users;
 
 [ApiController]
 [Route("api/users")]
-public class UsersController(IUserService userService) : ControllerBase
+public class UsersController(IUserService userService, ICurrentUserContext currentUserContext) : ControllerBase
 {
     private readonly IUserService _userService = userService;
+    private readonly ICurrentUserContext _currentUserContext = currentUserContext;
 
     [HttpGet]
+    [Authorize(Roles = "Admin")]
     public async Task<ActionResult<IEnumerable<UserWithVehiclesDto>>> GetAllUsers()
     {
         var users = await _userService.GetAllUsersAsync();
@@ -16,6 +20,7 @@ public class UsersController(IUserService userService) : ControllerBase
     }
 
     [HttpGet("by-name/{name}")]
+    [Authorize(Roles = "Admin")]
     public async Task<ActionResult<UserWithVehiclesDto>> GetUserByName(string name)
     {
         try
@@ -30,6 +35,7 @@ public class UsersController(IUserService userService) : ControllerBase
     }
 
     [HttpGet("{userId}")]
+    [Authorize(Roles = "Admin")]
     public async Task<ActionResult<UserWithVehiclesDto>> GetUser(Guid userId)
     {
         try
@@ -44,11 +50,29 @@ public class UsersController(IUserService userService) : ControllerBase
     }
 
     [HttpPost]
+    [AllowAnonymous]
     public async Task<ActionResult<UserDto>> CreateUser(CreateUserDto dto)
     {
         try
         {
-            var user = await _userService.CreateUserAsync(dto);
+            if (_currentUserContext.IsAuthenticated && !_currentUserContext.IsAdmin)
+                return Forbid();
+
+            var createDto = dto;
+            if (!_currentUserContext.IsAuthenticated)
+            {
+                createDto = new CreateUserDto
+                {
+                    Name = dto.Name,
+                    Email = dto.Email,
+                    Password = dto.Password,
+                    Cpf = dto.Cpf,
+                    Cellphone = dto.Cellphone,
+                    Role = UserRole.Customer
+                };
+            }
+
+            var user = await _userService.CreateUserAsync(createDto);
             return CreatedAtAction(nameof(GetUser), new { userId = user.UserId }, user);
         }
         catch (EmailAlreadyExistsException)
@@ -65,10 +89,20 @@ public class UsersController(IUserService userService) : ControllerBase
     // PUT -> Atualiza TODOS os campos da entidade
     // PATCH -> Atualização partical da entidade (ex: apenas o nome ou email)
     [HttpPatch("{userId}")]
+    [Authorize]
     public async Task<IActionResult> UpdateUser(Guid userId, UpdateUserDto dto)
     {
         try
         {
+            var actorUserId = _currentUserContext.GetRequiredUserId();
+            var actorRole = _currentUserContext.GetRequiredRole();
+
+            if (actorRole != UserRole.Admin && actorUserId != userId)
+                return Forbid();
+
+            if (actorRole != UserRole.Admin)
+                dto.Role = null;
+
             var updateUser = await _userService.UpdateUserAsync(userId, dto);
             return Ok(updateUser);
         }
@@ -84,6 +118,7 @@ public class UsersController(IUserService userService) : ControllerBase
     }
 
     [HttpDelete("{userId}")]
+    [Authorize(Roles = "Admin")]
     public async Task<IActionResult> DeleteUser(Guid userId)
     {
         try

--- a/Backend.Tests.Integration/Features/Accesses/AccessesControllerTests.cs
+++ b/Backend.Tests.Integration/Features/Accesses/AccessesControllerTests.cs
@@ -1,9 +1,5 @@
-using System.IdentityModel.Tokens.Jwt;
 using System.Net;
-using System.Net.Http.Headers;
 using System.Net.Http.Json;
-using System.Security.Claims;
-using System.Text;
 using Backend.Database;
 using Backend.Features.Accesses;
 using Backend.Features.Tags;
@@ -13,17 +9,12 @@ using Backend.Features.Users;
 using Backend.Features.Vehicles;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.IdentityModel.Tokens;
 using tests.Setup;
 
 namespace Backend.Tests.Integration.Features.Accesses;
 
 public class AccessesControllerTests(CustomWebApplicationFactory factory) : IClassFixture<CustomWebApplicationFactory>, IAsyncLifetime
 {
-    private const string JwtIssuer = "backend";
-    private const string JwtAudience = "frontend";
-    private const string JwtSecret = "your-super-secret-key-change-this-in-production-at-least-32-characters!";
-
     private readonly HttpClient _client = factory.CreateClient();
     private readonly IServiceScopeFactory _scopeFactory = factory.Services.GetRequiredService<IServiceScopeFactory>();
 
@@ -33,52 +24,6 @@ public class AccessesControllerTests(CustomWebApplicationFactory factory) : ICla
     }
 
     public Task DisposeAsync() => Task.CompletedTask;
-
-    private async Task<User> SeedUserAsync(UserRole role)
-    {
-        using var scope = _scopeFactory.CreateScope();
-        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
-
-        var user = new User
-        {
-            Name = $"User-{Guid.NewGuid()}",
-            Email = $"user_{Guid.NewGuid()}@example.com",
-            PasswordHash = "hash",
-            Role = role
-        };
-
-        db.Users.Add(user);
-        await db.SaveChangesAsync();
-
-        return user;
-    }
-
-    private static string CreateJwtToken(User user)
-    {
-        var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(JwtSecret));
-        var credentials = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
-
-        var claims = new List<Claim>
-        {
-            new(JwtRegisteredClaimNames.Sub, user.UserId.ToString()),
-            new("role", user.Role.ToString())
-        };
-
-        var token = new JwtSecurityToken(
-            issuer: JwtIssuer,
-            audience: JwtAudience,
-            claims: claims,
-            expires: DateTime.UtcNow.AddHours(1),
-            signingCredentials: credentials);
-
-        return new JwtSecurityTokenHandler().WriteToken(token);
-    }
-
-    private void SetAuthHeader(User user)
-    {
-        var token = CreateJwtToken(user);
-        _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
-    }
 
     private async Task<(Guid TagId, string Tid, string Epc)> SeedVehicleAndTagAsync(TagStatus status = TagStatus.IN_USE, string? plate = null)
     {
@@ -238,9 +183,9 @@ public class AccessesControllerTests(CustomWebApplicationFactory factory) : ICla
     [Fact]
     public async Task GetAccesses_WhenNotAuthenticated_ReturnsUnauthorized()
     {
-        _client.DefaultRequestHeaders.Authorization = null;
+        var anonymousClient = AuthTestHelper.CreateAnonymousClient(factory);
 
-        var response = await _client.GetAsync("/api/accesses");
+        var response = await anonymousClient.GetAsync("/api/accesses");
 
         Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
     }
@@ -248,10 +193,9 @@ public class AccessesControllerTests(CustomWebApplicationFactory factory) : ICla
     [Fact]
     public async Task GetAccesses_WhenCustomerAuthenticated_ReturnsForbidden()
     {
-        var customer = await SeedUserAsync(UserRole.Customer);
-        SetAuthHeader(customer);
+        var customerClient = await AuthTestHelper.CreateClientAsAsync(factory, UserRole.Customer);
 
-        var response = await _client.GetAsync("/api/accesses");
+        var response = await customerClient.GetAsync("/api/accesses");
 
         Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
     }
@@ -259,10 +203,9 @@ public class AccessesControllerTests(CustomWebApplicationFactory factory) : ICla
     [Fact]
     public async Task GetAccesses_WhenAdminAndEmpty_ReturnsOkWithEmptyList()
     {
-        var admin = await SeedUserAsync(UserRole.Admin);
-        SetAuthHeader(admin);
+        var adminClient = await AuthTestHelper.CreateClientAsAsync(factory, UserRole.Admin);
 
-        var response = await _client.GetAsync("/api/accesses");
+        var response = await adminClient.GetAsync("/api/accesses");
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         var result = await response.Content.ReadFromJsonAsync<List<AccessDto>>(CustomWebApplicationFactory.JsonOptions);
@@ -273,8 +216,7 @@ public class AccessesControllerTests(CustomWebApplicationFactory factory) : ICla
     [Fact]
     public async Task GetAccesses_WithAccessTypeExit_ReturnsOnlyExitsWithPlateAndNullableValue()
     {
-        var admin = await SeedUserAsync(UserRole.Admin);
-        SetAuthHeader(admin);
+        var adminClient = await AuthTestHelper.CreateClientAsAsync(factory, UserRole.Admin);
 
         var (entryTagId, _, _) = await SeedVehicleAndTagAsync();
         var (exitTagIdWithCharge, _, _) = await SeedVehicleAndTagAsync();
@@ -287,7 +229,7 @@ public class AccessesControllerTests(CustomWebApplicationFactory factory) : ICla
 
         await SeedAccessAsync(exitTagIdWithoutCharge, AccessType.Exit);
 
-        var response = await _client.GetAsync("/api/accesses?accessType=exit");
+        var response = await adminClient.GetAsync("/api/accesses?accessType=exit");
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
@@ -303,8 +245,7 @@ public class AccessesControllerTests(CustomWebApplicationFactory factory) : ICla
     [Fact]
     public async Task GetAccesses_WhenMultipleTransactionsForSameAccess_UsesLatestTransactionValue()
     {
-        var admin = await SeedUserAsync(UserRole.Admin);
-        SetAuthHeader(admin);
+        var adminClient = await AuthTestHelper.CreateClientAsAsync(factory, UserRole.Admin);
 
         var (tagId, _, _) = await SeedVehicleAndTagAsync();
         var accessId = await SeedAccessAsync(tagId, AccessType.Exit);
@@ -312,7 +253,7 @@ public class AccessesControllerTests(CustomWebApplicationFactory factory) : ICla
         await SeedTransactionAsync(accessId, 10m, DateTime.UtcNow.AddMinutes(-10));
         await SeedTransactionAsync(accessId, 25m, DateTime.UtcNow.AddMinutes(-1));
 
-        var response = await _client.GetAsync("/api/accesses?accessType=exit");
+        var response = await adminClient.GetAsync("/api/accesses?accessType=exit");
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 

--- a/Backend.Tests.Integration/Features/Dashboard/DashboardControllerTests.cs
+++ b/Backend.Tests.Integration/Features/Dashboard/DashboardControllerTests.cs
@@ -15,7 +15,6 @@ namespace tests.Features.Dashboard;
 public class DashboardControllerTests(CustomWebApplicationFactory factory)
     : IClassFixture<CustomWebApplicationFactory>, IAsyncLifetime
 {
-    private readonly HttpClient _client = factory.CreateClient();
     private readonly IServiceScopeFactory _scopeFactory =
         factory.Services.GetRequiredService<IServiceScopeFactory>();
 
@@ -76,7 +75,8 @@ public class DashboardControllerTests(CustomWebApplicationFactory factory)
     [Fact]
     public async Task GetOccupancy_WhenNoAccesses_ReturnsZeroOccupancy()
     {
-        var response = await _client.GetAsync("/api/dashboard/occupancy");
+        var adminClient = await AuthTestHelper.CreateClientAsAsync(factory, UserRole.Admin);
+        var response = await adminClient.GetAsync("/api/dashboard/occupancy");
 
         response.EnsureSuccessStatusCode();
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -92,10 +92,11 @@ public class DashboardControllerTests(CustomWebApplicationFactory factory)
     [Fact]
     public async Task GetOccupancy_WhenOneVehicleEntered_ReturnsOccupancyOne()
     {
+        var adminClient = await AuthTestHelper.CreateClientAsAsync(factory, UserRole.Admin);
         var (_, _, tag) = await SeedVehicleWithTagAsync("ENTR001");
         await SeedAccessAsync(tag.TagId, AccessType.Entry, DateTime.UtcNow);
 
-        var response = await _client.GetAsync("/api/dashboard/occupancy");
+        var response = await adminClient.GetAsync("/api/dashboard/occupancy");
 
         response.EnsureSuccessStatusCode();
         var body = await response.Content.ReadFromJsonAsync<OccupancyDto>(
@@ -110,12 +111,13 @@ public class DashboardControllerTests(CustomWebApplicationFactory factory)
     [Fact]
     public async Task GetOccupancy_WhenVehicleExited_IsNotCountedAsInside()
     {
+        var adminClient = await AuthTestHelper.CreateClientAsAsync(factory, UserRole.Admin);
         var (_, _, tag) = await SeedVehicleWithTagAsync("EXIT001");
         var baseTime = DateTime.UtcNow;
         await SeedAccessAsync(tag.TagId, AccessType.Entry, baseTime.AddMinutes(-10));
         await SeedAccessAsync(tag.TagId, AccessType.Exit, baseTime);
 
-        var response = await _client.GetAsync("/api/dashboard/occupancy");
+        var response = await adminClient.GetAsync("/api/dashboard/occupancy");
 
         response.EnsureSuccessStatusCode();
         var body = await response.Content.ReadFromJsonAsync<OccupancyDto>(
@@ -129,6 +131,7 @@ public class DashboardControllerTests(CustomWebApplicationFactory factory)
     [Fact]
     public async Task GetOccupancy_OnlyCountsVehiclesWhoseLastAccessIsEntry()
     {
+        var adminClient = await AuthTestHelper.CreateClientAsAsync(factory, UserRole.Admin);
         var baseTime = DateTime.UtcNow;
         //Access flow(Entry)
         var (_, _, tagA) = await SeedVehicleWithTagAsync("CAR-A");
@@ -143,7 +146,7 @@ public class DashboardControllerTests(CustomWebApplicationFactory factory)
         await SeedAccessAsync(tagC.TagId, AccessType.Exit, baseTime.AddMinutes(-40));
         await SeedAccessAsync(tagC.TagId, AccessType.Entry, baseTime.AddMinutes(-2));
 
-        var response = await _client.GetAsync("/api/dashboard/occupancy");
+        var response = await adminClient.GetAsync("/api/dashboard/occupancy");
 
         response.EnsureSuccessStatusCode();
         var body = await response.Content.ReadFromJsonAsync<OccupancyDto>(
@@ -162,14 +165,16 @@ public class DashboardControllerTests(CustomWebApplicationFactory factory)
     [Fact]
     public async Task GetOccupancy_ReturnsOkStatusCode()
     {
-        var response = await _client.GetAsync("/api/dashboard/occupancy");
+        var adminClient = await AuthTestHelper.CreateClientAsAsync(factory, UserRole.Admin);
+        var response = await adminClient.GetAsync("/api/dashboard/occupancy");
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
     }
 
     [Fact]
     public async Task GetMetrics_ShouldReturnOk()
     {
-        var response = await _client.GetAsync("/api/dashboard/metrics");
+        var adminClient = await AuthTestHelper.CreateClientAsAsync(factory, UserRole.Admin);
+        var response = await adminClient.GetAsync("/api/dashboard/metrics");
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
     }
@@ -177,7 +182,8 @@ public class DashboardControllerTests(CustomWebApplicationFactory factory)
     [Fact]
     public async Task GetMetrics_WhenNoAccesses_ShouldReturnZerosAndNullPeakTime()
     {
-        var response = await _client.GetAsync("/api/dashboard/metrics");
+        var adminClient = await AuthTestHelper.CreateClientAsAsync(factory, UserRole.Admin);
+        var response = await adminClient.GetAsync("/api/dashboard/metrics");
         response.EnsureSuccessStatusCode();
 
         var metrics = await response.Content.ReadFromJsonAsync<DashboardMetricsDto>(CustomWebApplicationFactory.JsonOptions);
@@ -191,7 +197,8 @@ public class DashboardControllerTests(CustomWebApplicationFactory factory)
     [Fact]
     public async Task GetMetrics_ShouldReturnCorrectFields()
     {
-        var response = await _client.GetAsync("/api/dashboard/metrics");
+        var adminClient = await AuthTestHelper.CreateClientAsAsync(factory, UserRole.Admin);
+        var response = await adminClient.GetAsync("/api/dashboard/metrics");
         response.EnsureSuccessStatusCode();
 
         var metrics = await response.Content.ReadFromJsonAsync<DashboardMetricsDto>(CustomWebApplicationFactory.JsonOptions);
@@ -199,5 +206,45 @@ public class DashboardControllerTests(CustomWebApplicationFactory factory)
         Assert.NotNull(metrics);
         Assert.True(metrics.EntriesLastHour >= 0);
         Assert.True(metrics.ExitsLastHour >= 0);
+    }
+
+    [Fact]
+    public async Task GetOccupancy_WhenNotAuthenticated_ReturnsUnauthorized()
+    {
+        var anonymousClient = AuthTestHelper.CreateAnonymousClient(factory);
+
+        var response = await anonymousClient.GetAsync("/api/dashboard/occupancy");
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetMetrics_WhenNotAuthenticated_ReturnsUnauthorized()
+    {
+        var anonymousClient = AuthTestHelper.CreateAnonymousClient(factory);
+
+        var response = await anonymousClient.GetAsync("/api/dashboard/metrics");
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetOccupancy_WhenCustomerAuthenticated_ReturnsForbidden()
+    {
+        var customerClient = await AuthTestHelper.CreateClientAsAsync(factory, UserRole.Customer);
+
+        var response = await customerClient.GetAsync("/api/dashboard/occupancy");
+
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetMetrics_WhenCustomerAuthenticated_ReturnsForbidden()
+    {
+        var customerClient = await AuthTestHelper.CreateClientAsAsync(factory, UserRole.Customer);
+
+        var response = await customerClient.GetAsync("/api/dashboard/metrics");
+
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
     }
 }

--- a/Backend.Tests.Integration/Features/ParkingPrices/ParkingPricesControllerTests.cs
+++ b/Backend.Tests.Integration/Features/ParkingPrices/ParkingPricesControllerTests.cs
@@ -1,6 +1,9 @@
 using System.Net;
 using System.Net.Http.Json;
+using Backend.Database;
 using Backend.Features.ParkingPrices;
+using Backend.Features.Users;
+using Microsoft.Extensions.DependencyInjection;
 using tests.Setup;
 
 namespace Backend.Tests.Integration.Features.ParkingPrices;
@@ -9,6 +12,7 @@ public class ParkingPricesControllerTests(CustomWebApplicationFactory factory) :
 {
     private readonly CustomWebApplicationFactory _factory = factory;
     private readonly HttpClient _client = factory.CreateClient();
+    private readonly IServiceScopeFactory _scopeFactory = factory.Services.GetRequiredService<IServiceScopeFactory>();
 
     public async Task InitializeAsync()
     {
@@ -16,6 +20,66 @@ public class ParkingPricesControllerTests(CustomWebApplicationFactory factory) :
     }
 
     public Task DisposeAsync() => Task.CompletedTask;
+
+    public static TheoryData<string, string> WriteEndpoints()
+        => new()
+        {
+            { "POST", "/api/parking-prices" },
+            { "PATCH", "/api/parking-prices/11111111-1111-1111-1111-111111111111" },
+            { "DELETE", "/api/parking-prices/11111111-1111-1111-1111-111111111111" }
+        };
+
+    [Theory]
+    [MemberData(nameof(WriteEndpoints))]
+    public async Task WriteEndpoints_WhenNotAuthenticated_ReturnUnauthorized(string method, string path)
+    {
+        var anonymousClient = AuthTestHelper.CreateAnonymousClient(_factory);
+
+        var response = await SendWriteRequestAsync(anonymousClient, method, path);
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Theory]
+    [MemberData(nameof(WriteEndpoints))]
+    public async Task WriteEndpoints_WhenCustomerAuthenticated_ReturnForbidden(string method, string path)
+    {
+        var customerClient = await AuthTestHelper.CreateClientAsAsync(_factory, UserRole.Customer);
+
+        var response = await SendWriteRequestAsync(customerClient, method, path);
+
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task ReadEndpoints_WhenAnonymous_AreAccessible()
+    {
+        var seeded = await SeedParkingPriceAsync();
+        var anonymousClient = AuthTestHelper.CreateAnonymousClient(_factory);
+
+        var listResponse = await anonymousClient.GetAsync("/api/parking-prices");
+        var byIdResponse = await anonymousClient.GetAsync($"/api/parking-prices/{seeded.ParkingPriceId}");
+        var currentResponse = await anonymousClient.GetAsync("/parking-pricing");
+
+        Assert.Equal(HttpStatusCode.OK, listResponse.StatusCode);
+        Assert.Equal(HttpStatusCode.OK, byIdResponse.StatusCode);
+        Assert.Equal(HttpStatusCode.OK, currentResponse.StatusCode);
+    }
+
+    [Fact]
+    public async Task ReadEndpoints_WhenCustomer_AreAccessible()
+    {
+        var seeded = await SeedParkingPriceAsync();
+        var customerClient = await AuthTestHelper.CreateClientAsAsync(_factory, UserRole.Customer);
+
+        var listResponse = await customerClient.GetAsync("/api/parking-prices");
+        var byIdResponse = await customerClient.GetAsync($"/api/parking-prices/{seeded.ParkingPriceId}");
+        var currentResponse = await customerClient.GetAsync("/parking-pricing");
+
+        Assert.Equal(HttpStatusCode.OK, listResponse.StatusCode);
+        Assert.Equal(HttpStatusCode.OK, byIdResponse.StatusCode);
+        Assert.Equal(HttpStatusCode.OK, currentResponse.StatusCode);
+    }
 
     [Fact]
     public async Task GetAllParkingPrices_ShouldReturnSuccess()
@@ -32,6 +96,8 @@ public class ParkingPricesControllerTests(CustomWebApplicationFactory factory) :
     [Fact]
     public async Task CreateParkingPrice_ShouldReturnCreatedPrice()
     {
+        var adminClient = await AuthTestHelper.CreateClientAsAsync(_factory, UserRole.Admin);
+
         var newPrice = new CreateParkingPriceDto
         {
             ToleranceMinutes = 15,
@@ -40,7 +106,7 @@ public class ParkingPricesControllerTests(CustomWebApplicationFactory factory) :
             ThresholdMinutes = 180
         };
 
-        var response = await _client.PostAsync("/api/parking-prices", JsonContent.Create(newPrice, options: CustomWebApplicationFactory.JsonOptions));
+        var response = await adminClient.PostAsync("/api/parking-prices", JsonContent.Create(newPrice, options: CustomWebApplicationFactory.JsonOptions));
 
         response.EnsureSuccessStatusCode();
         Assert.Equal(HttpStatusCode.Created, response.StatusCode);
@@ -56,6 +122,8 @@ public class ParkingPricesControllerTests(CustomWebApplicationFactory factory) :
     [Fact]
     public async Task GetParkingPrice_ShouldReturnCreatedPrice()
     {
+        var adminClient = await AuthTestHelper.CreateClientAsAsync(_factory, UserRole.Admin);
+
         var newPrice = new CreateParkingPriceDto
         {
             ToleranceMinutes = 20,
@@ -64,7 +132,7 @@ public class ParkingPricesControllerTests(CustomWebApplicationFactory factory) :
             ThresholdMinutes = 240
         };
 
-        var createResponse = await _client.PostAsync("/api/parking-prices", JsonContent.Create(newPrice, options: CustomWebApplicationFactory.JsonOptions));
+        var createResponse = await adminClient.PostAsync("/api/parking-prices", JsonContent.Create(newPrice, options: CustomWebApplicationFactory.JsonOptions));
         createResponse.EnsureSuccessStatusCode();
         var createdPrice = await createResponse.Content.ReadFromJsonAsync<ParkingPricesDto>(CustomWebApplicationFactory.JsonOptions);
 
@@ -91,6 +159,8 @@ public class ParkingPricesControllerTests(CustomWebApplicationFactory factory) :
     [Fact]
     public async Task UpdateParkingPrice_ShouldReturnUpdatedPrice()
     {
+        var adminClient = await AuthTestHelper.CreateClientAsAsync(_factory, UserRole.Admin);
+
         var newPrice = new CreateParkingPriceDto
         {
             ToleranceMinutes = 15,
@@ -99,7 +169,7 @@ public class ParkingPricesControllerTests(CustomWebApplicationFactory factory) :
             ThresholdMinutes = 180
         };
 
-        var createResponse = await _client.PostAsync("/api/parking-prices", JsonContent.Create(newPrice, options: CustomWebApplicationFactory.JsonOptions));
+        var createResponse = await adminClient.PostAsync("/api/parking-prices", JsonContent.Create(newPrice, options: CustomWebApplicationFactory.JsonOptions));
         createResponse.EnsureSuccessStatusCode();
         var createdPrice = await createResponse.Content.ReadFromJsonAsync<ParkingPricesDto>(CustomWebApplicationFactory.JsonOptions);
 
@@ -109,7 +179,7 @@ public class ParkingPricesControllerTests(CustomWebApplicationFactory factory) :
             HourlyRate = 7.00m
         };
 
-        var updateResponse = await _client.PatchAsync($"/api/parking-prices/{createdPrice?.ParkingPriceId}", JsonContent.Create(updateDto, options: CustomWebApplicationFactory.JsonOptions));
+        var updateResponse = await adminClient.PatchAsync($"/api/parking-prices/{createdPrice?.ParkingPriceId}", JsonContent.Create(updateDto, options: CustomWebApplicationFactory.JsonOptions));
         updateResponse.EnsureSuccessStatusCode();
         var updatedPrice = await updateResponse.Content.ReadFromJsonAsync<ParkingPricesDto>(CustomWebApplicationFactory.JsonOptions);
 
@@ -122,10 +192,11 @@ public class ParkingPricesControllerTests(CustomWebApplicationFactory factory) :
     [Fact]
     public async Task UpdateParkingPrice_WithInvalidId_ShouldReturnNotFound()
     {
+        var adminClient = await AuthTestHelper.CreateClientAsAsync(_factory, UserRole.Admin);
         var invalidId = Guid.NewGuid();
         var updateDto = new UpdateParkingPriceDto { BasePrice = 25.00m };
 
-        var response = await _client.PatchAsync($"/api/parking-prices/{invalidId}", JsonContent.Create(updateDto, options: CustomWebApplicationFactory.JsonOptions));
+        var response = await adminClient.PatchAsync($"/api/parking-prices/{invalidId}", JsonContent.Create(updateDto, options: CustomWebApplicationFactory.JsonOptions));
 
         Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
     }
@@ -133,6 +204,8 @@ public class ParkingPricesControllerTests(CustomWebApplicationFactory factory) :
     [Fact]
     public async Task UpdateParkingPrice_WithPartialData_ShouldUpdateOnlyProvidedFields()
     {
+        var adminClient = await AuthTestHelper.CreateClientAsAsync(_factory, UserRole.Admin);
+
         var newPrice = new CreateParkingPriceDto
         {
             ToleranceMinutes = 15,
@@ -141,13 +214,13 @@ public class ParkingPricesControllerTests(CustomWebApplicationFactory factory) :
             ThresholdMinutes = 180
         };
 
-        var createResponse = await _client.PostAsync("/api/parking-prices", JsonContent.Create(newPrice, options: CustomWebApplicationFactory.JsonOptions));
+        var createResponse = await adminClient.PostAsync("/api/parking-prices", JsonContent.Create(newPrice, options: CustomWebApplicationFactory.JsonOptions));
         createResponse.EnsureSuccessStatusCode();
         var createdPrice = await createResponse.Content.ReadFromJsonAsync<ParkingPricesDto>(CustomWebApplicationFactory.JsonOptions);
 
         var updateDto = new UpdateParkingPriceDto { BasePrice = 30.00m };
 
-        var updateResponse = await _client.PatchAsync($"/api/parking-prices/{createdPrice?.ParkingPriceId}", JsonContent.Create(updateDto, options: CustomWebApplicationFactory.JsonOptions));
+        var updateResponse = await adminClient.PatchAsync($"/api/parking-prices/{createdPrice?.ParkingPriceId}", JsonContent.Create(updateDto, options: CustomWebApplicationFactory.JsonOptions));
         updateResponse.EnsureSuccessStatusCode();
         var updatedPrice = await updateResponse.Content.ReadFromJsonAsync<ParkingPricesDto>(CustomWebApplicationFactory.JsonOptions);
 
@@ -160,6 +233,8 @@ public class ParkingPricesControllerTests(CustomWebApplicationFactory factory) :
     [Fact]
     public async Task DeleteParkingPrice_ShouldReturnNoContent()
     {
+        var adminClient = await AuthTestHelper.CreateClientAsAsync(_factory, UserRole.Admin);
+
         var newPrice = new CreateParkingPriceDto
         {
             ToleranceMinutes = 15,
@@ -168,11 +243,11 @@ public class ParkingPricesControllerTests(CustomWebApplicationFactory factory) :
             ThresholdMinutes = 180
         };
 
-        var createResponse = await _client.PostAsync("/api/parking-prices", JsonContent.Create(newPrice, options: CustomWebApplicationFactory.JsonOptions));
+        var createResponse = await adminClient.PostAsync("/api/parking-prices", JsonContent.Create(newPrice, options: CustomWebApplicationFactory.JsonOptions));
         createResponse.EnsureSuccessStatusCode();
         var createdPrice = await createResponse.Content.ReadFromJsonAsync<ParkingPricesDto>(CustomWebApplicationFactory.JsonOptions);
 
-        var deleteResponse = await _client.DeleteAsync($"/api/parking-prices/{createdPrice?.ParkingPriceId}");
+        var deleteResponse = await adminClient.DeleteAsync($"/api/parking-prices/{createdPrice?.ParkingPriceId}");
 
         Assert.Equal(HttpStatusCode.NoContent, deleteResponse.StatusCode);
 
@@ -183,9 +258,10 @@ public class ParkingPricesControllerTests(CustomWebApplicationFactory factory) :
     [Fact]
     public async Task DeleteParkingPrice_WithInvalidId_ShouldReturnNotFound()
     {
+        var adminClient = await AuthTestHelper.CreateClientAsAsync(_factory, UserRole.Admin);
         var invalidId = Guid.NewGuid();
 
-        var response = await _client.DeleteAsync($"/api/parking-prices/{invalidId}");
+        var response = await adminClient.DeleteAsync($"/api/parking-prices/{invalidId}");
 
         Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
     }
@@ -193,6 +269,8 @@ public class ParkingPricesControllerTests(CustomWebApplicationFactory factory) :
     [Fact]
     public async Task MultipleParkingPrices_ShouldBeListedCorrectly()
     {
+        var adminClient = await AuthTestHelper.CreateClientAsAsync(_factory, UserRole.Admin);
+
         var prices = new[]
         {
             new CreateParkingPriceDto { ToleranceMinutes = 15, BasePrice = 15.00m, HourlyRate = 5.00m, ThresholdMinutes = 180 },
@@ -202,7 +280,7 @@ public class ParkingPricesControllerTests(CustomWebApplicationFactory factory) :
 
         foreach (var price in prices)
         {
-            var response = await _client.PostAsync("/api/parking-prices", JsonContent.Create(price, options: CustomWebApplicationFactory.JsonOptions));
+            var response = await adminClient.PostAsync("/api/parking-prices", JsonContent.Create(price, options: CustomWebApplicationFactory.JsonOptions));
             response.EnsureSuccessStatusCode();
         }
 
@@ -213,9 +291,12 @@ public class ParkingPricesControllerTests(CustomWebApplicationFactory factory) :
         Assert.NotNull(allPrices);
         Assert.True(allPrices.Count >= 3);
     }
+
     [Fact]
     public async Task GetCurrentParkingPricing_ShouldReturnLatestPrice()
     {
+        var adminClient = await AuthTestHelper.CreateClientAsAsync(_factory, UserRole.Admin);
+
         var newPrice1 = new CreateParkingPriceDto
         {
             ToleranceMinutes = 15,
@@ -223,7 +304,7 @@ public class ParkingPricesControllerTests(CustomWebApplicationFactory factory) :
             HourlyRate = 5.00m,
             ThresholdMinutes = 180
         };
-        await _client.PostAsync("/api/parking-prices", JsonContent.Create(newPrice1, options: CustomWebApplicationFactory.JsonOptions));
+        await adminClient.PostAsync("/api/parking-prices", JsonContent.Create(newPrice1, options: CustomWebApplicationFactory.JsonOptions));
 
         var newPrice2 = new CreateParkingPriceDto
         {
@@ -232,7 +313,7 @@ public class ParkingPricesControllerTests(CustomWebApplicationFactory factory) :
             HourlyRate = 6.00m,
             ThresholdMinutes = 240
         };
-        var createResponse2 = await _client.PostAsync("/api/parking-prices", JsonContent.Create(newPrice2, options: CustomWebApplicationFactory.JsonOptions));
+        var createResponse2 = await adminClient.PostAsync("/api/parking-prices", JsonContent.Create(newPrice2, options: CustomWebApplicationFactory.JsonOptions));
         var createdPrice2 = await createResponse2.Content.ReadFromJsonAsync<ParkingPricesDto>(CustomWebApplicationFactory.JsonOptions);
 
         var getResponse = await _client.GetAsync("/parking-pricing");
@@ -249,5 +330,44 @@ public class ParkingPricesControllerTests(CustomWebApplicationFactory factory) :
     {
         var response = await _client.GetAsync("/parking-pricing");
         Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    private async Task<HttpResponseMessage> SendWriteRequestAsync(HttpClient client, string method, string path)
+    {
+        return method switch
+        {
+            "POST" => await client.PostAsJsonAsync(path, new CreateParkingPriceDto
+            {
+                ToleranceMinutes = 15,
+                BasePrice = 10m,
+                HourlyRate = 5m,
+                ThresholdMinutes = 120
+            }, CustomWebApplicationFactory.JsonOptions),
+            "PATCH" => await client.PatchAsync(path, JsonContent.Create(new UpdateParkingPriceDto
+            {
+                BasePrice = 20m
+            }, options: CustomWebApplicationFactory.JsonOptions)),
+            "DELETE" => await client.DeleteAsync(path),
+            _ => throw new ArgumentOutOfRangeException(nameof(method), method, "Unsupported method")
+        };
+    }
+
+    private async Task<ParkingPrice> SeedParkingPriceAsync()
+    {
+        using var scope = _scopeFactory.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+
+        var entity = new ParkingPrice
+        {
+            ToleranceMinutes = 10,
+            BasePrice = 12m,
+            HourlyRate = 4m,
+            ThresholdMinutes = 120
+        };
+
+        db.ParkingPrices.Add(entity);
+        await db.SaveChangesAsync();
+
+        return entity;
     }
 }

--- a/Backend.Tests.Integration/Features/Tags/TagControllerTests.cs
+++ b/Backend.Tests.Integration/Features/Tags/TagControllerTests.cs
@@ -11,7 +11,7 @@ namespace tests.Features.Tags;
 
 public class TagControllerTests(CustomWebApplicationFactory factory) : IClassFixture<CustomWebApplicationFactory>, IAsyncLifetime
 {
-    private readonly HttpClient _client = factory.CreateClient();
+    private readonly IServiceScopeFactory _scopeFactory = factory.Services.GetRequiredService<IServiceScopeFactory>();
 
     public async Task InitializeAsync()
     {
@@ -22,7 +22,7 @@ public class TagControllerTests(CustomWebApplicationFactory factory) : IClassFix
 
     private async Task SeedUserAsync(User user)
     {
-        using var scope = factory.Services.CreateScope();
+        using var scope = _scopeFactory.CreateScope();
         var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
         db.Users.Add(user);
         await db.SaveChangesAsync();
@@ -30,7 +30,7 @@ public class TagControllerTests(CustomWebApplicationFactory factory) : IClassFix
 
     private async Task SeedVehicleAsync(Vehicle vehicle)
     {
-        using var scope = factory.Services.CreateScope();
+        using var scope = _scopeFactory.CreateScope();
         var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
         db.Vehicles.Add(vehicle);
         await db.SaveChangesAsync();
@@ -38,7 +38,7 @@ public class TagControllerTests(CustomWebApplicationFactory factory) : IClassFix
 
     private async Task SeedTagAsync(Tag tag)
     {
-        using var scope = factory.Services.CreateScope();
+        using var scope = _scopeFactory.CreateScope();
         var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
 
         if (tag.Vehicle != null)
@@ -50,12 +50,55 @@ public class TagControllerTests(CustomWebApplicationFactory factory) : IClassFix
         await db.SaveChangesAsync();
     }
 
+    public static IEnumerable<object[]> ProtectedTagEndpoints()
+    {
+        yield return ["GET", "/api/tags"];
+        yield return ["POST", "/api/tags"];
+        yield return ["PATCH", $"/api/tags/{Guid.NewGuid()}/deactivate"];
+        yield return ["PATCH", $"/api/tags/{Guid.NewGuid()}/assign-vehicle"];
+    }
+
+    [Theory]
+    [MemberData(nameof(ProtectedTagEndpoints))]
+    public async Task ProtectedEndpoints_WhenNotAuthenticated_ReturnUnauthorized(string method, string path)
+    {
+        var anonymousClient = AuthTestHelper.CreateAnonymousClient(factory);
+
+        HttpResponseMessage response = method switch
+        {
+            "GET" => await anonymousClient.GetAsync(path),
+            "POST" => await anonymousClient.PostAsync(path, JsonContent.Create(new { })),
+            "PATCH" => await anonymousClient.PatchAsync(path, JsonContent.Create(new { })),
+            _ => throw new InvalidOperationException($"Unsupported HTTP method: {method}")
+        };
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Theory]
+    [MemberData(nameof(ProtectedTagEndpoints))]
+    public async Task ProtectedEndpoints_WhenCustomerAuthenticated_ReturnForbidden(string method, string path)
+    {
+        var customerClient = await AuthTestHelper.CreateClientAsAsync(factory, UserRole.Customer);
+
+        HttpResponseMessage response = method switch
+        {
+            "GET" => await customerClient.GetAsync(path),
+            "POST" => await customerClient.PostAsync(path, JsonContent.Create(new { })),
+            "PATCH" => await customerClient.PatchAsync(path, JsonContent.Create(new { })),
+            _ => throw new InvalidOperationException($"Unsupported HTTP method: {method}")
+        };
+
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+    }
+
     [Fact]
     public async Task CreateTag_ShouldReturnCreatedTag()
     {
+        var adminClient = await AuthTestHelper.CreateClientAsAsync(factory, UserRole.Admin);
         var newTag = new CreateTagDto { Epc = "EPC-001", Tid = "TID-001" };
 
-        var response = await _client.PostAsync("/api/tags", JsonContent.Create(newTag));
+        var response = await adminClient.PostAsync("/api/tags", JsonContent.Create(newTag));
 
         Assert.Equal(HttpStatusCode.Created, response.StatusCode);
 
@@ -69,12 +112,13 @@ public class TagControllerTests(CustomWebApplicationFactory factory) : IClassFix
     [Fact]
     public async Task GetAllTags_ShouldReturnCreatedTag()
     {
+        var adminClient = await AuthTestHelper.CreateClientAsAsync(factory, UserRole.Admin);
         var newTag = new CreateTagDto { Epc = "EPC-002", Tid = "TID-002" };
 
-        var createResponse = await _client.PostAsync("/api/tags", JsonContent.Create(newTag));
+        var createResponse = await adminClient.PostAsync("/api/tags", JsonContent.Create(newTag));
         Assert.Equal(HttpStatusCode.Created, createResponse.StatusCode);
 
-        var response = await _client.GetAsync("/api/tags");
+        var response = await adminClient.GetAsync("/api/tags");
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
@@ -88,13 +132,14 @@ public class TagControllerTests(CustomWebApplicationFactory factory) : IClassFix
     [Fact]
     public async Task GetAllTags_WithStatusFilter_ShouldReturnOnlyMatchingTags()
     {
+        var adminClient = await AuthTestHelper.CreateClientAsAsync(factory, UserRole.Admin);
         var availableTag = new Tag { Status = Backend.Features.Tags.Enums.TagStatus.AVAILABLE, Epc = "EPC-012", Tid = "TID-012" };
         var inactiveTag = new Tag { Status = Backend.Features.Tags.Enums.TagStatus.INACTIVE, Epc = "EPC-013", Tid = "TID-013" };
 
         await SeedTagAsync(availableTag);
         await SeedTagAsync(inactiveTag);
 
-        var response = await _client.GetAsync("/api/tags?status=AVAILABLE");
+        var response = await adminClient.GetAsync("/api/tags?status=AVAILABLE");
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
@@ -109,12 +154,13 @@ public class TagControllerTests(CustomWebApplicationFactory factory) : IClassFix
     [Fact]
     public async Task CreateTag_WhenTagAlreadyExists_ShouldReturnConflict()
     {
+        var adminClient = await AuthTestHelper.CreateClientAsAsync(factory, UserRole.Admin);
         var newTag = new CreateTagDto { Epc = "EPC-003", Tid = "TID-003" };
 
-        var firstResponse = await _client.PostAsync("/api/tags", JsonContent.Create(newTag));
+        var firstResponse = await adminClient.PostAsync("/api/tags", JsonContent.Create(newTag));
         Assert.Equal(HttpStatusCode.Created, firstResponse.StatusCode);
 
-        var secondResponse = await _client.PostAsync("/api/tags", JsonContent.Create(newTag));
+        var secondResponse = await adminClient.PostAsync("/api/tags", JsonContent.Create(newTag));
 
         Assert.Equal(HttpStatusCode.Conflict, secondResponse.StatusCode);
     }
@@ -122,7 +168,9 @@ public class TagControllerTests(CustomWebApplicationFactory factory) : IClassFix
     [Fact]
     public async Task GetAllTags_WithInvalidStatus_ShouldReturnBadRequest()
     {
-        var response = await _client.GetAsync("/api/tags?status=INVALID");
+        var adminClient = await AuthTestHelper.CreateClientAsAsync(factory, UserRole.Admin);
+
+        var response = await adminClient.GetAsync("/api/tags?status=INVALID");
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
     }
@@ -130,7 +178,9 @@ public class TagControllerTests(CustomWebApplicationFactory factory) : IClassFix
     [Fact]
     public async Task DeactivateTag_ShouldReturnNotFound_WhenTagDoesNotExist()
     {
-        var response = await _client.PatchAsync($"/api/tags/{Guid.NewGuid()}/deactivate", null);
+        var adminClient = await AuthTestHelper.CreateClientAsAsync(factory, UserRole.Admin);
+
+        var response = await adminClient.PatchAsync($"/api/tags/{Guid.NewGuid()}/deactivate", null);
 
         Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
     }
@@ -138,10 +188,11 @@ public class TagControllerTests(CustomWebApplicationFactory factory) : IClassFix
     [Fact]
     public async Task DeactivateTag_ShouldDeactivateExistingTag()
     {
+        var adminClient = await AuthTestHelper.CreateClientAsAsync(factory, UserRole.Admin);
         var seeded = new Tag { Status = Backend.Features.Tags.Enums.TagStatus.AVAILABLE, Epc = "EPC-005", Tid = "TID-005" };
         await SeedTagAsync(seeded);
 
-        var response = await _client.PatchAsync($"/api/tags/{seeded.TagId}/deactivate", null);
+        var response = await adminClient.PatchAsync($"/api/tags/{seeded.TagId}/deactivate", null);
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
@@ -154,6 +205,7 @@ public class TagControllerTests(CustomWebApplicationFactory factory) : IClassFix
     [Fact]
     public async Task AssignVehicle_ShouldAssignVehicleToTag()
     {
+        var adminClient = await AuthTestHelper.CreateClientAsAsync(factory, UserRole.Admin);
         var user = new User { Name = "Alice", Email = "alice@example.com", PasswordHash = "hash", Role = UserRole.Admin };
         await SeedUserAsync(user);
 
@@ -169,7 +221,7 @@ public class TagControllerTests(CustomWebApplicationFactory factory) : IClassFix
         var seeded = new Tag { Status = Backend.Features.Tags.Enums.TagStatus.AVAILABLE, Epc = "EPC-006", Tid = "TID-006" };
         await SeedTagAsync(seeded);
 
-        var response = await _client.PatchAsJsonAsync($"/api/tags/{seeded.TagId}/assign-vehicle", new AssignVehicleDto { VehicleId = vehicle.VehicleId });
+        var response = await adminClient.PatchAsJsonAsync($"/api/tags/{seeded.TagId}/assign-vehicle", new AssignVehicleDto { VehicleId = vehicle.VehicleId });
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
@@ -183,6 +235,7 @@ public class TagControllerTests(CustomWebApplicationFactory factory) : IClassFix
     [Fact]
     public async Task AssignVehicle_ShouldReturnConflict_WhenVehicleAlreadyHasActiveTag()
     {
+        var adminClient = await AuthTestHelper.CreateClientAsAsync(factory, UserRole.Admin);
         var user = new User { Name = "Bob", Email = "bob@example.com", PasswordHash = "hash", Role = UserRole.Admin };
         await SeedUserAsync(user);
 
@@ -201,10 +254,10 @@ public class TagControllerTests(CustomWebApplicationFactory factory) : IClassFix
         await SeedTagAsync(firstTag);
         await SeedTagAsync(secondTag);
 
-        var firstResponse = await _client.PatchAsJsonAsync($"/api/tags/{firstTag.TagId}/assign-vehicle", new AssignVehicleDto { VehicleId = vehicle.VehicleId });
+        var firstResponse = await adminClient.PatchAsJsonAsync($"/api/tags/{firstTag.TagId}/assign-vehicle", new AssignVehicleDto { VehicleId = vehicle.VehicleId });
         Assert.Equal(HttpStatusCode.OK, firstResponse.StatusCode);
 
-        var secondResponse = await _client.PatchAsJsonAsync($"/api/tags/{secondTag.TagId}/assign-vehicle", new AssignVehicleDto { VehicleId = vehicle.VehicleId });
+        var secondResponse = await adminClient.PatchAsJsonAsync($"/api/tags/{secondTag.TagId}/assign-vehicle", new AssignVehicleDto { VehicleId = vehicle.VehicleId });
 
         Assert.Equal(HttpStatusCode.Conflict, secondResponse.StatusCode);
     }
@@ -212,6 +265,7 @@ public class TagControllerTests(CustomWebApplicationFactory factory) : IClassFix
     [Fact]
     public async Task AssignVehicle_ShouldReturnConflict_WhenTagIsAlreadyAssigned()
     {
+        var adminClient = await AuthTestHelper.CreateClientAsAsync(factory, UserRole.Admin);
         var user = new User { Name = "Carol", Email = "carol@example.com", PasswordHash = "hash", Role = UserRole.Admin };
         await SeedUserAsync(user);
 
@@ -233,7 +287,7 @@ public class TagControllerTests(CustomWebApplicationFactory factory) : IClassFix
         };
         await SeedTagAsync(seeded);
 
-        var response = await _client.PatchAsJsonAsync($"/api/tags/{seeded.TagId}/assign-vehicle", new AssignVehicleDto { VehicleId = vehicle.VehicleId });
+        var response = await adminClient.PatchAsJsonAsync($"/api/tags/{seeded.TagId}/assign-vehicle", new AssignVehicleDto { VehicleId = vehicle.VehicleId });
 
         Assert.Equal(HttpStatusCode.Conflict, response.StatusCode);
     }
@@ -241,6 +295,7 @@ public class TagControllerTests(CustomWebApplicationFactory factory) : IClassFix
     [Fact]
     public async Task AssignVehicle_ShouldReturnConflict_WhenTagIsInactive()
     {
+        var adminClient = await AuthTestHelper.CreateClientAsAsync(factory, UserRole.Admin);
         var user = new User { Name = "Dana", Email = "dana@example.com", PasswordHash = "hash", Role = UserRole.Admin };
         await SeedUserAsync(user);
 
@@ -261,7 +316,7 @@ public class TagControllerTests(CustomWebApplicationFactory factory) : IClassFix
         };
         await SeedTagAsync(seeded);
 
-        var response = await _client.PatchAsJsonAsync($"/api/tags/{seeded.TagId}/assign-vehicle", new AssignVehicleDto { VehicleId = vehicle.VehicleId });
+        var response = await adminClient.PatchAsJsonAsync($"/api/tags/{seeded.TagId}/assign-vehicle", new AssignVehicleDto { VehicleId = vehicle.VehicleId });
 
         Assert.Equal(HttpStatusCode.Conflict, response.StatusCode);
     }
@@ -269,6 +324,7 @@ public class TagControllerTests(CustomWebApplicationFactory factory) : IClassFix
     [Fact]
     public async Task AssignVehicle_ShouldReturnNotFound_WhenTagDoesNotExist()
     {
+        var adminClient = await AuthTestHelper.CreateClientAsAsync(factory, UserRole.Admin);
         var user = new User { Name = "Eva", Email = "eva@example.com", PasswordHash = "hash", Role = UserRole.Admin };
         await SeedUserAsync(user);
 
@@ -281,7 +337,7 @@ public class TagControllerTests(CustomWebApplicationFactory factory) : IClassFix
         };
         await SeedVehicleAsync(vehicle);
 
-        var response = await _client.PatchAsJsonAsync($"/api/tags/{Guid.NewGuid()}/assign-vehicle", new AssignVehicleDto { VehicleId = vehicle.VehicleId });
+        var response = await adminClient.PatchAsJsonAsync($"/api/tags/{Guid.NewGuid()}/assign-vehicle", new AssignVehicleDto { VehicleId = vehicle.VehicleId });
 
         Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
     }
@@ -289,10 +345,11 @@ public class TagControllerTests(CustomWebApplicationFactory factory) : IClassFix
     [Fact]
     public async Task AssignVehicle_ShouldReturnNotFound_WhenVehicleDoesNotExist()
     {
+        var adminClient = await AuthTestHelper.CreateClientAsAsync(factory, UserRole.Admin);
         var seeded = new Tag { Status = Backend.Features.Tags.Enums.TagStatus.AVAILABLE, Epc = "EPC-011", Tid = "TID-011" };
         await SeedTagAsync(seeded);
 
-        var response = await _client.PatchAsJsonAsync($"/api/tags/{seeded.TagId}/assign-vehicle", new AssignVehicleDto { VehicleId = Guid.NewGuid() });
+        var response = await adminClient.PatchAsJsonAsync($"/api/tags/{seeded.TagId}/assign-vehicle", new AssignVehicleDto { VehicleId = Guid.NewGuid() });
 
         Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
     }

--- a/Backend.Tests.Integration/Features/Transactions/TransactionControllerTests.cs
+++ b/Backend.Tests.Integration/Features/Transactions/TransactionControllerTests.cs
@@ -1,25 +1,16 @@
 using System.Net;
-using System.Net.Http.Headers;
 using System.Net.Http.Json;
-using System.IdentityModel.Tokens.Jwt;
-using System.Security.Claims;
-using System.Text;
 using Backend.Database;
 using Backend.Features.Transactions;
 using Backend.Features.Users;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.IdentityModel.Tokens;
 using tests.Setup;
 
 namespace tests.Features.Transactions;
 
 public class TransactionControllerTests(CustomWebApplicationFactory factory) : IClassFixture<CustomWebApplicationFactory>, IAsyncLifetime
 {
-    private const string JwtIssuer = "backend";
-    private const string JwtAudience = "frontend";
-    private const string JwtSecret = "your-super-secret-key-change-this-in-production-at-least-32-characters!";
-
-    private readonly HttpClient _client = factory.CreateClient();
     private readonly IServiceScopeFactory _scopeFactory = factory.Services.GetRequiredService<IServiceScopeFactory>();
 
     public async Task InitializeAsync()
@@ -47,39 +38,19 @@ public class TransactionControllerTests(CustomWebApplicationFactory factory) : I
         return user;
     }
 
-    private static string CreateJwtToken(User user)
+    private async Task<User> GetUserByEmailAsync(string email)
     {
-        var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(JwtSecret));
-        var credentials = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
+        using var scope = _scopeFactory.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
 
-        var claims = new List<Claim>
-        {
-            new(JwtRegisteredClaimNames.Sub, user.UserId.ToString()),
-            new("role", user.Role.ToString())
-        };
-
-        var token = new JwtSecurityToken(
-            issuer: JwtIssuer,
-            audience: JwtAudience,
-            claims: claims,
-            expires: DateTime.UtcNow.AddHours(1),
-            signingCredentials: credentials);
-
-        return new JwtSecurityTokenHandler().WriteToken(token);
-    }
-
-    private void SetAuthHeader(User user)
-    {
-        var token = CreateJwtToken(user);
-        _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        return await db.Users.FirstAsync(u => u.Email == email);
     }
 
     [Fact]
     public async Task CreateTransaction_AdminCanCreateForOtherUser_ReturnsCreated()
     {
-        var admin = await SeedUserAsync(UserRole.Admin);
+        var adminClient = await AuthTestHelper.CreateClientAsAsync(factory, UserRole.Admin);
         var customer = await SeedUserAsync(UserRole.Customer);
-        SetAuthHeader(admin);
 
         var payload = new CreateTransactionDto
         {
@@ -88,7 +59,7 @@ public class TransactionControllerTests(CustomWebApplicationFactory factory) : I
             Amount = 10m
         };
 
-        var response = await _client.PostAsync("/api/transactions", JsonContent.Create(payload, options: CustomWebApplicationFactory.JsonOptions));
+        var response = await adminClient.PostAsync("/api/transactions", JsonContent.Create(payload, options: CustomWebApplicationFactory.JsonOptions));
 
         Assert.Equal(HttpStatusCode.Created, response.StatusCode);
 
@@ -101,8 +72,9 @@ public class TransactionControllerTests(CustomWebApplicationFactory factory) : I
     [Fact]
     public async Task CreateTransaction_CustomerCanCreateForSelf_WhenUserIdOmitted()
     {
-        var customer = await SeedUserAsync(UserRole.Customer);
-        SetAuthHeader(customer);
+        const string customerEmail = "customer.self@example.com";
+        var customerClient = await AuthTestHelper.CreateClientAsAsync(factory, UserRole.Customer, email: customerEmail);
+        var customer = await GetUserByEmailAsync(customerEmail);
 
         var payload = new CreateTransactionDto
         {
@@ -110,7 +82,7 @@ public class TransactionControllerTests(CustomWebApplicationFactory factory) : I
             Amount = 25m
         };
 
-        var response = await _client.PostAsync("/api/transactions", JsonContent.Create(payload, options: CustomWebApplicationFactory.JsonOptions));
+        var response = await customerClient.PostAsync("/api/transactions", JsonContent.Create(payload, options: CustomWebApplicationFactory.JsonOptions));
 
         Assert.Equal(HttpStatusCode.Created, response.StatusCode);
 
@@ -122,9 +94,8 @@ public class TransactionControllerTests(CustomWebApplicationFactory factory) : I
     [Fact]
     public async Task CreateTransaction_CustomerCannotCreateForOtherUser_ReturnsForbidden()
     {
-        var customer = await SeedUserAsync(UserRole.Customer);
+        var customerClient = await AuthTestHelper.CreateClientAsAsync(factory, UserRole.Customer);
         var otherCustomer = await SeedUserAsync(UserRole.Customer);
-        SetAuthHeader(customer);
 
         var payload = new CreateTransactionDto
         {
@@ -133,7 +104,7 @@ public class TransactionControllerTests(CustomWebApplicationFactory factory) : I
             Amount = 10m
         };
 
-        var response = await _client.PostAsync("/api/transactions", JsonContent.Create(payload, options: CustomWebApplicationFactory.JsonOptions));
+        var response = await customerClient.PostAsync("/api/transactions", JsonContent.Create(payload, options: CustomWebApplicationFactory.JsonOptions));
 
         Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
     }
@@ -141,8 +112,9 @@ public class TransactionControllerTests(CustomWebApplicationFactory factory) : I
     [Fact]
     public async Task CreateTransaction_AdminOmittingUserId_DefaultsToSelf()
     {
-        var admin = await SeedUserAsync(UserRole.Admin);
-        SetAuthHeader(admin);
+        const string adminEmail = "admin.self@example.com";
+        var adminClient = await AuthTestHelper.CreateClientAsAsync(factory, UserRole.Admin, email: adminEmail);
+        var admin = await GetUserByEmailAsync(adminEmail);
 
         var payload = new CreateTransactionDto
         {
@@ -150,7 +122,7 @@ public class TransactionControllerTests(CustomWebApplicationFactory factory) : I
             Amount = 50m
         };
 
-        var response = await _client.PostAsync("/api/transactions", JsonContent.Create(payload, options: CustomWebApplicationFactory.JsonOptions));
+        var response = await adminClient.PostAsync("/api/transactions", JsonContent.Create(payload, options: CustomWebApplicationFactory.JsonOptions));
 
         Assert.Equal(HttpStatusCode.Created, response.StatusCode);
 
@@ -162,7 +134,7 @@ public class TransactionControllerTests(CustomWebApplicationFactory factory) : I
     [Fact]
     public async Task CreateTransaction_WhenUnauthorized_ReturnsUnauthorized()
     {
-        _client.DefaultRequestHeaders.Authorization = null;
+        var anonymousClient = AuthTestHelper.CreateAnonymousClient(factory);
 
         var payload = new CreateTransactionDto
         {
@@ -170,7 +142,7 @@ public class TransactionControllerTests(CustomWebApplicationFactory factory) : I
             Amount = 15m
         };
 
-        var response = await _client.PostAsync("/api/transactions", JsonContent.Create(payload, options: CustomWebApplicationFactory.JsonOptions));
+        var response = await anonymousClient.PostAsync("/api/transactions", JsonContent.Create(payload, options: CustomWebApplicationFactory.JsonOptions));
 
         Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
     }
@@ -178,8 +150,7 @@ public class TransactionControllerTests(CustomWebApplicationFactory factory) : I
     [Fact]
     public async Task CreateTransaction_WhenTargetUserDoesNotExist_ReturnsNotFound()
     {
-        var admin = await SeedUserAsync(UserRole.Admin);
-        SetAuthHeader(admin);
+        var adminClient = await AuthTestHelper.CreateClientAsAsync(factory, UserRole.Admin);
 
         var payload = new CreateTransactionDto
         {
@@ -188,7 +159,7 @@ public class TransactionControllerTests(CustomWebApplicationFactory factory) : I
             Amount = 10m
         };
 
-        var response = await _client.PostAsync("/api/transactions", JsonContent.Create(payload, options: CustomWebApplicationFactory.JsonOptions));
+        var response = await adminClient.PostAsync("/api/transactions", JsonContent.Create(payload, options: CustomWebApplicationFactory.JsonOptions));
 
         Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
     }
@@ -196,8 +167,7 @@ public class TransactionControllerTests(CustomWebApplicationFactory factory) : I
     [Fact]
     public async Task CreateTransaction_WhenPayloadInvalid_ReturnsBadRequest()
     {
-        var admin = await SeedUserAsync(UserRole.Admin);
-        SetAuthHeader(admin);
+        var adminClient = await AuthTestHelper.CreateClientAsAsync(factory, UserRole.Admin);
 
         var payload = new CreateTransactionDto
         {
@@ -205,7 +175,7 @@ public class TransactionControllerTests(CustomWebApplicationFactory factory) : I
             Amount = 0m
         };
 
-        var response = await _client.PostAsync("/api/transactions", JsonContent.Create(payload, options: CustomWebApplicationFactory.JsonOptions));
+        var response = await adminClient.PostAsync("/api/transactions", JsonContent.Create(payload, options: CustomWebApplicationFactory.JsonOptions));
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
     }
@@ -213,10 +183,9 @@ public class TransactionControllerTests(CustomWebApplicationFactory factory) : I
     [Fact]
     public async Task GetMyTransactions_WhenAuthenticated_ReturnsOk()
     {
-        var customer = await SeedUserAsync(UserRole.Customer);
-        SetAuthHeader(customer);
+        var customerClient = await AuthTestHelper.CreateClientAsAsync(factory, UserRole.Customer);
 
-        var response = await _client.GetAsync("/api/transactions");
+        var response = await customerClient.GetAsync("/api/transactions");
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
     }
@@ -224,9 +193,9 @@ public class TransactionControllerTests(CustomWebApplicationFactory factory) : I
     [Fact]
     public async Task GetMyTransactions_WhenNotAuthenticated_ReturnsUnauthorized()
     {
-        _client.DefaultRequestHeaders.Authorization = null;
+        var anonymousClient = AuthTestHelper.CreateAnonymousClient(factory);
 
-        var response = await _client.GetAsync("/api/transactions");
+        var response = await anonymousClient.GetAsync("/api/transactions");
 
         Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
     }
@@ -234,10 +203,9 @@ public class TransactionControllerTests(CustomWebApplicationFactory factory) : I
     [Fact]
     public async Task GetMyTransactions_WhenNoTransactions_ReturnsEmptyList()
     {
-        var customer = await SeedUserAsync(UserRole.Customer);
-        SetAuthHeader(customer);
+        var customerClient = await AuthTestHelper.CreateClientAsAsync(factory, UserRole.Customer);
 
-        var response = await _client.GetAsync("/api/transactions");
+        var response = await customerClient.GetAsync("/api/transactions");
         var transactions = await response.Content.ReadFromJsonAsync<List<TransactionDto>>(CustomWebApplicationFactory.JsonOptions);
 
         Assert.NotNull(transactions);
@@ -247,13 +215,12 @@ public class TransactionControllerTests(CustomWebApplicationFactory factory) : I
     [Fact]
     public async Task GetMyTransactions_AfterCreating_ReturnsOwnTransactions()
     {
-        var customer = await SeedUserAsync(UserRole.Customer);
-        SetAuthHeader(customer);
+        var customerClient = await AuthTestHelper.CreateClientAsAsync(factory, UserRole.Customer);
 
         var dto = new CreateTransactionDto { Description = "Depósito", Amount = 100 };
-        await _client.PostAsync("/api/transactions", JsonContent.Create(dto, options: CustomWebApplicationFactory.JsonOptions));
+        await customerClient.PostAsync("/api/transactions", JsonContent.Create(dto, options: CustomWebApplicationFactory.JsonOptions));
 
-        var response = await _client.GetAsync("/api/transactions");
+        var response = await customerClient.GetAsync("/api/transactions");
         var transactions = await response.Content.ReadFromJsonAsync<List<TransactionDto>>(CustomWebApplicationFactory.JsonOptions);
 
         Assert.NotNull(transactions);
@@ -264,15 +231,13 @@ public class TransactionControllerTests(CustomWebApplicationFactory factory) : I
     [Fact]
     public async Task GetMyTransactions_ReturnsOnlyOwnTransactions()
     {
-        var customer1 = await SeedUserAsync(UserRole.Customer);
-        var customer2 = await SeedUserAsync(UserRole.Customer);
+        var customer1Client = await AuthTestHelper.CreateClientAsAsync(factory, UserRole.Customer);
+        var customer2Client = await AuthTestHelper.CreateClientAsAsync(factory, UserRole.Customer);
 
-        SetAuthHeader(customer1);
         var dto = new CreateTransactionDto { Description = "Depósito", Amount = 50 };
-        await _client.PostAsync("/api/transactions", JsonContent.Create(dto, options: CustomWebApplicationFactory.JsonOptions));
+        await customer1Client.PostAsync("/api/transactions", JsonContent.Create(dto, options: CustomWebApplicationFactory.JsonOptions));
 
-        SetAuthHeader(customer2);
-        var response = await _client.GetAsync("/api/transactions");
+        var response = await customer2Client.GetAsync("/api/transactions");
         var transactions = await response.Content.ReadFromJsonAsync<List<TransactionDto>>(CustomWebApplicationFactory.JsonOptions);
 
         Assert.Empty(transactions!);

--- a/Backend.Tests.Integration/Features/Users/UserControllerTests.cs
+++ b/Backend.Tests.Integration/Features/Users/UserControllerTests.cs
@@ -3,6 +3,7 @@ using System.Net.Http.Json;
 using Backend.Database;
 using Backend.Features.Transactions;
 using Backend.Features.Users;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using tests.Setup;
 
@@ -20,60 +21,135 @@ public class UserControllerTests(CustomWebApplicationFactory factory) : IClassFi
 
     public Task DisposeAsync() => Task.CompletedTask;
 
-    [Fact]
-    public async Task GetUsers_ShouldReturnSuccess()
+    public static IEnumerable<object[]> AdminProtectedEndpoints()
     {
-        var response = await _client.GetAsync("/api/users");
+        yield return ["GET", "/api/users"];
+        yield return ["GET", $"/api/users/{Guid.Parse("11111111-1111-1111-1111-111111111111")}"];
+        yield return ["GET", "/api/users/by-name/any"];
+        yield return ["DELETE", $"/api/users/{Guid.Parse("22222222-2222-2222-2222-222222222222")}"];
+    }
 
-        response.EnsureSuccessStatusCode();
-        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    [Theory]
+    [MemberData(nameof(AdminProtectedEndpoints))]
+    public async Task AdminProtectedEndpoints_WhenAnonymous_ReturnUnauthorized(string method, string path)
+    {
+        var client = AuthTestHelper.CreateAnonymousClient(_factory);
 
-        var users = await response.Content.ReadFromJsonAsync<List<UserDto>>(CustomWebApplicationFactory.JsonOptions);
-        Assert.NotNull(users);
-        Assert.Empty(users);
+        var response = method switch
+        {
+            "GET" => await client.GetAsync(path),
+            "DELETE" => await client.DeleteAsync(path),
+            _ => throw new InvalidOperationException($"Unsupported method '{method}'")
+        };
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Theory]
+    [MemberData(nameof(AdminProtectedEndpoints))]
+    public async Task AdminProtectedEndpoints_WhenCustomer_ReturnForbidden(string method, string path)
+    {
+        var customerClient = await AuthTestHelper.CreateClientAsAsync(_factory, UserRole.Customer);
+
+        var response = method switch
+        {
+            "GET" => await customerClient.GetAsync(path),
+            "DELETE" => await customerClient.DeleteAsync(path),
+            _ => throw new InvalidOperationException($"Unsupported method '{method}'")
+        };
+
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
     }
 
     [Fact]
-    public async Task CreateUser_ShouldReturnCreatedUser()
+    public async Task CreateUser_WhenAnonymous_AlwaysCreatesCustomer()
     {
-        var newUser = new CreateUserDto { Name = "Fulaninho", Email = "fulano@email.com", Password = "password123", Role = UserRole.Admin };
+        var anonymousClient = AuthTestHelper.CreateAnonymousClient(_factory);
+        var newUser = new CreateUserDto
+        {
+            Name = "Signup User",
+            Email = "signup@email.com",
+            Password = "password123",
+            Role = UserRole.Admin
+        };
 
-        var response = await _client.PostAsync("/api/users", JsonContent.Create(newUser, options: CustomWebApplicationFactory.JsonOptions));
+        var response = await anonymousClient.PostAsync("/api/users", JsonContent.Create(newUser, options: CustomWebApplicationFactory.JsonOptions));
 
         response.EnsureSuccessStatusCode();
         Assert.Equal(HttpStatusCode.Created, response.StatusCode);
 
         var createdUser = await response.Content.ReadFromJsonAsync<UserDto>(CustomWebApplicationFactory.JsonOptions);
         Assert.NotNull(createdUser);
-        Assert.Equal(newUser.Name, createdUser.Name);
-        Assert.Equal(newUser.Email, createdUser.Email);
+        Assert.Equal(UserRole.Customer, createdUser.Role);
     }
 
     [Fact]
-    public async Task GetUser_ShouldReturnCreatedUser()
+    public async Task CreateUser_WhenCustomerAuthenticated_ReturnsForbidden()
     {
-        var newUser = new CreateUserDto { Name = "Fulaninho", Email = "fulano@email.com", Password = "password123", Role = UserRole.Admin };
+        var customerClient = await AuthTestHelper.CreateClientAsAsync(_factory, UserRole.Customer);
+        var dto = new CreateUserDto
+        {
+            Name = "Blocked",
+            Email = "blocked@email.com",
+            Password = "password123",
+            Role = UserRole.Customer
+        };
 
-        var createResponse = await _client.PostAsync("/api/users", JsonContent.Create(newUser, options: CustomWebApplicationFactory.JsonOptions));
-        createResponse.EnsureSuccessStatusCode();
-        var createdUser = await createResponse.Content.ReadFromJsonAsync<UserDto>(CustomWebApplicationFactory.JsonOptions);
+        var response = await customerClient.PostAsync("/api/users", JsonContent.Create(dto, options: CustomWebApplicationFactory.JsonOptions));
 
-        var getResponse = await _client.GetAsync($"/api/users/{createdUser?.UserId}");
-        getResponse.EnsureSuccessStatusCode();
-        var fetchedUser = await getResponse.Content.ReadFromJsonAsync<UserDto>(CustomWebApplicationFactory.JsonOptions);
-
-        Assert.NotNull(fetchedUser);
-        Assert.Equal(createdUser?.UserId, fetchedUser.UserId);
-        Assert.Equal(createdUser?.Name, fetchedUser.Name);
-        Assert.Equal(createdUser?.Email, fetchedUser.Email);
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
     }
 
     [Fact]
-    public async Task GetUser_ShouldReturnBalanceFromTransactions()
+    public async Task CreateUser_WhenAdminAuthenticated_CanCreateAdmin()
     {
-        var newUser = new CreateUserDto { Name = "Balance User", Email = "balance@email.com", Password = "password123", Role = UserRole.Admin };
+        var adminClient = await AuthTestHelper.CreateClientAsAsync(_factory, UserRole.Admin);
+        var dto = new CreateUserDto
+        {
+            Name = "Admin Created",
+            Email = "new-admin@email.com",
+            Password = "password123",
+            Role = UserRole.Admin
+        };
 
-        var createResponse = await _client.PostAsync("/api/users", JsonContent.Create(newUser, options: CustomWebApplicationFactory.JsonOptions));
+        var response = await adminClient.PostAsync("/api/users", JsonContent.Create(dto, options: CustomWebApplicationFactory.JsonOptions));
+
+        response.EnsureSuccessStatusCode();
+
+        var createdUser = await response.Content.ReadFromJsonAsync<UserDto>(CustomWebApplicationFactory.JsonOptions);
+        Assert.NotNull(createdUser);
+        Assert.Equal(UserRole.Admin, createdUser.Role);
+    }
+
+    [Fact]
+    public async Task GetUsers_WhenAdmin_ReturnsSuccess()
+    {
+        var adminClient = await AuthTestHelper.CreateClientAsAsync(_factory, UserRole.Admin);
+
+        var response = await adminClient.GetAsync("/api/users");
+
+        response.EnsureSuccessStatusCode();
+        var users = await response.Content.ReadFromJsonAsync<List<UserDto>>(CustomWebApplicationFactory.JsonOptions);
+        Assert.NotNull(users);
+    }
+
+    [Fact]
+    public async Task GetUser_WhenAdminAndNotFound_ReturnsNotFound()
+    {
+        var adminClient = await AuthTestHelper.CreateClientAsAsync(_factory, UserRole.Admin);
+
+        var response = await adminClient.GetAsync($"/api/users/{Guid.NewGuid()}");
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetUser_WhenAdmin_ReturnsBalanceFromTransactions()
+    {
+        var adminClient = await AuthTestHelper.CreateClientAsAsync(_factory, UserRole.Admin);
+        var newUser = new CreateUserDto { Name = "Balance User", Email = "balance@email.com", Password = "password123", Role = UserRole.Customer };
+
+        var createResponse = await adminClient.PostAsync("/api/users", JsonContent.Create(newUser, options: CustomWebApplicationFactory.JsonOptions));
         createResponse.EnsureSuccessStatusCode();
         var createdUser = await createResponse.Content.ReadFromJsonAsync<UserDto>(CustomWebApplicationFactory.JsonOptions);
 
@@ -98,7 +174,7 @@ public class UserControllerTests(CustomWebApplicationFactory factory) : IClassFi
             await db.SaveChangesAsync();
         }
 
-        var getResponse = await _client.GetAsync($"/api/users/{createdUser?.UserId}");
+        var getResponse = await adminClient.GetAsync($"/api/users/{createdUser?.UserId}");
         getResponse.EnsureSuccessStatusCode();
         var fetchedUser = await getResponse.Content.ReadFromJsonAsync<UserWithVehiclesDto>(CustomWebApplicationFactory.JsonOptions);
 
@@ -107,153 +183,101 @@ public class UserControllerTests(CustomWebApplicationFactory factory) : IClassFi
     }
 
     [Fact]
-    public async Task GetUser_WhenNotFound_ShouldReturnNotFound()
+    public async Task UpdateUser_WhenAnonymous_ReturnsUnauthorized()
     {
-        var response = await _client.GetAsync($"/api/users/{Guid.NewGuid()}");
-        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+        var anonymousClient = AuthTestHelper.CreateAnonymousClient(_factory);
+        var response = await anonymousClient.PatchAsync($"/api/users/{Guid.NewGuid()}", JsonContent.Create(new UpdateUserDto { Name = "No Auth" }, options: CustomWebApplicationFactory.JsonOptions));
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task UpdateUser_WhenCustomerUpdatesAnotherUser_ReturnsForbidden()
+    {
+        var anonymousClient = AuthTestHelper.CreateAnonymousClient(_factory);
+        var createResponse = await anonymousClient.PostAsync("/api/users", JsonContent.Create(new CreateUserDto
+        {
+            Name = "Target",
+            Email = "target@email.com",
+            Password = "password123",
+            Role = UserRole.Customer
+        }, options: CustomWebApplicationFactory.JsonOptions));
+
+        var targetUser = await createResponse.Content.ReadFromJsonAsync<UserDto>(CustomWebApplicationFactory.JsonOptions);
+        var customerClient = await AuthTestHelper.CreateClientAsAsync(_factory, UserRole.Customer);
+
+        var response = await customerClient.PatchAsync($"/api/users/{targetUser!.UserId}", JsonContent.Create(new UpdateUserDto { Name = "Hack" }, options: CustomWebApplicationFactory.JsonOptions));
+
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task UpdateUser_WhenCustomerUpdatesSelf_CanUpdateAndCannotEscalateRole()
+    {
+        var customerEmail = $"self_{Guid.NewGuid()}@email.com";
+        var customerClient = await AuthTestHelper.CreateClientAsAsync(_factory, UserRole.Customer, email: customerEmail);
+        var userId = await GetUserIdByEmailAsync(customerEmail);
+
+        var response = await customerClient.PatchAsync(
+            $"/api/users/{userId}",
+            JsonContent.Create(new UpdateUserDto
+            {
+                Name = "Updated Self",
+                Role = UserRole.Admin
+            }, options: CustomWebApplicationFactory.JsonOptions)
+        );
+
+        response.EnsureSuccessStatusCode();
+
+        var updated = await response.Content.ReadFromJsonAsync<UserDto>(CustomWebApplicationFactory.JsonOptions);
+        Assert.NotNull(updated);
+        Assert.Equal("Updated Self", updated.Name);
+        Assert.Equal(UserRole.Customer, updated.Role);
+    }
+
+    [Fact]
+    public async Task UpdateUser_WhenAdminUpdatingRole_ShouldUpdateRole()
+    {
+        var adminClient = await AuthTestHelper.CreateClientAsAsync(_factory, UserRole.Admin);
+        var createResponse = await adminClient.PostAsync("/api/users", JsonContent.Create(new CreateUserDto
+        {
+            Name = "User",
+            Email = "user@email.com",
+            Password = "password123",
+            Role = UserRole.Customer
+        }, options: CustomWebApplicationFactory.JsonOptions));
+
+        var createdUser = await createResponse.Content.ReadFromJsonAsync<UserDto>(CustomWebApplicationFactory.JsonOptions);
+
+        var response = await adminClient.PatchAsync(
+            $"/api/users/{createdUser!.UserId}",
+            JsonContent.Create(new UpdateUserDto { Role = UserRole.Admin }, options: CustomWebApplicationFactory.JsonOptions)
+        );
+
+        response.EnsureSuccessStatusCode();
+
+        var updatedUser = await response.Content.ReadFromJsonAsync<UserDto>(CustomWebApplicationFactory.JsonOptions);
+        Assert.NotNull(updatedUser);
+        Assert.Equal(UserRole.Admin, updatedUser.Role);
     }
 
     [Fact]
     public async Task CreateUser_WhenEmailAlreadyExists_ShouldReturnConflict()
     {
-        var newUser = new CreateUserDto { Name = "Fulaninho", Email = "fulano@email.com", Password = "password123", Role = UserRole.Admin };
-        await _client.PostAsync("/api/users", JsonContent.Create(newUser, options: CustomWebApplicationFactory.JsonOptions));
+        var anonymousClient = AuthTestHelper.CreateAnonymousClient(_factory);
+        var newUser = new CreateUserDto { Name = "Fulaninho", Email = "fulano@email.com", Password = "password123", Role = UserRole.Customer };
+        await anonymousClient.PostAsync("/api/users", JsonContent.Create(newUser, options: CustomWebApplicationFactory.JsonOptions));
 
-        var response = await _client.PostAsync("/api/users", JsonContent.Create(newUser, options: CustomWebApplicationFactory.JsonOptions));
+        var response = await anonymousClient.PostAsync("/api/users", JsonContent.Create(newUser, options: CustomWebApplicationFactory.JsonOptions));
         Assert.Equal(HttpStatusCode.Conflict, response.StatusCode);
     }
 
-    [Fact]
-    public async Task DeleteUser_ShouldReturnNoContent()
+    private async Task<Guid> GetUserIdByEmailAsync(string email)
     {
-        var newUser = new CreateUserDto { Name = "Fulaninho", Email = "fulano@email.com", Password = "password123", Role = UserRole.Admin };
-        var createResponse = await _client.PostAsync("/api/users", JsonContent.Create(newUser, options: CustomWebApplicationFactory.JsonOptions));
-        var createdUser = await createResponse.Content.ReadFromJsonAsync<UserDto>(CustomWebApplicationFactory.JsonOptions);
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
 
-        var response = await _client.DeleteAsync($"/api/users/{createdUser?.UserId}");
-        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
-    }
-
-    [Fact]
-    public async Task UpdateUser_ShouldReturnUpdatedUser()
-    {
-        var newUser = new CreateUserDto { Name = "Fulaninho", Email = "fulano@email.com", Password = "password123", Role = UserRole.Admin };
-        var createResponse = await _client.PostAsync("/api/users", JsonContent.Create(newUser, options: CustomWebApplicationFactory.JsonOptions));
-        var createdUser = await createResponse.Content.ReadFromJsonAsync<UserDto>(CustomWebApplicationFactory.JsonOptions);
-
-        var updateDto = new UpdateUserDto { Name = "Atualizado", Email = "atualizado@email.com" };
-        var response = await _client.PatchAsync($"/api/users/{createdUser?.UserId}", JsonContent.Create(updateDto, options: CustomWebApplicationFactory.JsonOptions));
-
-        response.EnsureSuccessStatusCode();
-        var updatedUser = await response.Content.ReadFromJsonAsync<UserDto>(CustomWebApplicationFactory.JsonOptions);
-        Assert.Equal("Atualizado", updatedUser?.Name);
-    }
-
-    [Fact]
-    public async Task UpdateUser_WhenUpdatingOnlyName_ShouldUpdateNameOnly()
-    {
-        var newUser = new CreateUserDto { Name = "Original", Email = "original@email.com", Password = "password123", Role = UserRole.Admin };
-        var createResponse = await _client.PostAsync("/api/users", JsonContent.Create(newUser, options: CustomWebApplicationFactory.JsonOptions));
-        var createdUser = await createResponse.Content.ReadFromJsonAsync<UserDto>(CustomWebApplicationFactory.JsonOptions);
-
-        var updateDto = new UpdateUserDto { Name = "Updated" };
-        var response = await _client.PatchAsync($"/api/users/{createdUser?.UserId}", JsonContent.Create(updateDto, options: CustomWebApplicationFactory.JsonOptions));
-
-        response.EnsureSuccessStatusCode();
-        var updatedUser = await response.Content.ReadFromJsonAsync<UserDto>(CustomWebApplicationFactory.JsonOptions);
-        Assert.Equal("Updated", updatedUser?.Name);
-        Assert.Equal("original@email.com", updatedUser?.Email);
-    }
-
-    [Fact]
-    public async Task UpdateUser_WhenUpdatingOnlyEmail_ShouldUpdateEmailOnly()
-    {
-        var newUser = new CreateUserDto { Name = "User", Email = "old@email.com", Password = "password123", Role = UserRole.Admin };
-        var createResponse = await _client.PostAsync("/api/users", JsonContent.Create(newUser, options: CustomWebApplicationFactory.JsonOptions));
-        var createdUser = await createResponse.Content.ReadFromJsonAsync<UserDto>(CustomWebApplicationFactory.JsonOptions);
-
-        var updateDto = new UpdateUserDto { Email = "new@email.com" };
-        var response = await _client.PatchAsync($"/api/users/{createdUser?.UserId}", JsonContent.Create(updateDto, options: CustomWebApplicationFactory.JsonOptions));
-
-        response.EnsureSuccessStatusCode();
-        var updatedUser = await response.Content.ReadFromJsonAsync<UserDto>(CustomWebApplicationFactory.JsonOptions);
-        Assert.Equal("User", updatedUser?.Name);
-        Assert.Equal("new@email.com", updatedUser?.Email);
-    }
-
-    [Fact]
-    public async Task UpdateUser_WhenUpdatingOnlyRole_ShouldUpdateRoleOnly()
-    {
-        var newUser = new CreateUserDto { Name = "User", Email = "user@email.com", Password = "password123", Role = UserRole.Admin };
-        var createResponse = await _client.PostAsync("/api/users", JsonContent.Create(newUser, options: CustomWebApplicationFactory.JsonOptions));
-        var createdUser = await createResponse.Content.ReadFromJsonAsync<UserDto>(CustomWebApplicationFactory.JsonOptions);
-
-        var updateDto = new UpdateUserDto { Role = UserRole.Customer };
-        var response = await _client.PatchAsync($"/api/users/{createdUser?.UserId}", JsonContent.Create(updateDto, options: CustomWebApplicationFactory.JsonOptions));
-
-        response.EnsureSuccessStatusCode();
-        var updatedUser = await response.Content.ReadFromJsonAsync<UserDto>(CustomWebApplicationFactory.JsonOptions);
-        Assert.Equal("User", updatedUser?.Name);
-        Assert.Equal("user@email.com", updatedUser?.Email);
-        Assert.Equal(UserRole.Customer, updatedUser?.Role);
-    }
-
-    [Fact]
-    public async Task GetUser_ShouldReturnVehiclesWhenUserHasVehicles()
-    {
-        var newUser = new CreateUserDto { Name = "Ricardo", Email = "ricardo@email.com", Password = "password123", Role = UserRole.Admin };
-        var createResponse = await _client.PostAsync("/api/users", JsonContent.Create(newUser, options: CustomWebApplicationFactory.JsonOptions));
-        var createdUser = await createResponse.Content.ReadFromJsonAsync<UserDto>(CustomWebApplicationFactory.JsonOptions);
-
-        var getResponse = await _client.GetAsync($"/api/users/{createdUser?.UserId}");
-        getResponse.EnsureSuccessStatusCode();
-        var fetchedUser = await getResponse.Content.ReadFromJsonAsync<UserWithVehiclesDto>(CustomWebApplicationFactory.JsonOptions);
-
-        Assert.NotNull(fetchedUser);
-        Assert.NotNull(fetchedUser.Vehicles);
-    }
-
-    [Fact]
-    public async Task UpdateUser_WhenEmailAlreadyExists_ShouldReturnConflict()
-    {
-        var user1 = new CreateUserDto { Name = "User1", Email = "user1@email.com", Password = "password123", Role = UserRole.Admin };
-        var user2 = new CreateUserDto { Name = "User2", Email = "user2@email.com", Password = "password123", Role = UserRole.Admin };
-
-        await _client.PostAsync("/api/users", JsonContent.Create(user1, options: CustomWebApplicationFactory.JsonOptions));
-        var create2Response = await _client.PostAsync("/api/users", JsonContent.Create(user2, options: CustomWebApplicationFactory.JsonOptions));
-        var createdUser2 = await create2Response.Content.ReadFromJsonAsync<UserDto>(CustomWebApplicationFactory.JsonOptions);
-
-        var updateDto = new UpdateUserDto { Email = "user1@email.com" };
-        var response = await _client.PatchAsync($"/api/users/{createdUser2?.UserId}", JsonContent.Create(updateDto, options: CustomWebApplicationFactory.JsonOptions));
-
-        Assert.Equal(HttpStatusCode.Conflict, response.StatusCode);
-    }
-
-    [Fact]
-    public async Task DeleteUser_WhenNotFound_ShouldReturnNotFound()
-    {
-        var response = await _client.DeleteAsync($"/api/users/{Guid.NewGuid()}");
-        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
-    }
-
-    [Fact]
-    public async Task GetUserByName_ShouldReturnUser()
-    {
-        var newUser = new CreateUserDto { Name = "Ricardo", Email = "ricardo@email.com", Password = "password123", Role = UserRole.Admin };
-        await _client.PostAsync("/api/users", JsonContent.Create(newUser, options: CustomWebApplicationFactory.JsonOptions));
-
-        var response = await _client.GetAsync("/api/users/by-name/Ricardo");
-        response.EnsureSuccessStatusCode();
-        var user = await response.Content.ReadFromJsonAsync<UserDto>(CustomWebApplicationFactory.JsonOptions);
-
-        Assert.NotNull(user);
-        Assert.Equal("Ricardo", user.Name);
-    }
-
-    [Fact]
-    public async Task GetUserByName_WhenNotFound_ShouldReturnNotFound()
-    {
-        var response = await _client.GetAsync("/api/users/by-name/Inexistente");
-        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+        var user = await db.Users.FirstAsync(u => u.Email == email);
+        return user.UserId;
     }
 }

--- a/Backend.Tests.Integration/Setup/AuthTestHelper.cs
+++ b/Backend.Tests.Integration/Setup/AuthTestHelper.cs
@@ -1,0 +1,79 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Net.Http.Headers;
+using System.Security.Claims;
+using System.Text;
+using Backend.Database;
+using Backend.Features.Users;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.IdentityModel.Tokens;
+
+namespace tests.Setup;
+
+public static class AuthTestHelper
+{
+    private const string JwtIssuer = "backend";
+    private const string JwtAudience = "frontend";
+    private const string JwtSecret = "your-super-secret-key-change-this-in-production-at-least-32-characters!";
+
+    public static HttpClient CreateAnonymousClient(CustomWebApplicationFactory factory)
+        => factory.CreateClient();
+
+    public static async Task<HttpClient> CreateClientAsAsync(
+        CustomWebApplicationFactory factory,
+        UserRole role,
+        string? name = null,
+        string? email = null)
+    {
+        var scopeFactory = factory.Services.GetRequiredService<IServiceScopeFactory>();
+        var user = await SeedUserAsync(scopeFactory, role, name, email);
+
+        var client = factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", CreateJwtToken(user));
+
+        return client;
+    }
+
+    private static async Task<User> SeedUserAsync(
+        IServiceScopeFactory scopeFactory,
+        UserRole role,
+        string? name,
+        string? email)
+    {
+        using var scope = scopeFactory.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+
+        var user = new User
+        {
+            Name = name ?? $"User-{Guid.NewGuid()}",
+            Email = email ?? $"user_{Guid.NewGuid()}@example.com",
+            PasswordHash = "hash",
+            Role = role
+        };
+
+        db.Users.Add(user);
+        await db.SaveChangesAsync();
+
+        return user;
+    }
+
+    private static string CreateJwtToken(User user)
+    {
+        var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(JwtSecret));
+        var credentials = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
+
+        var claims = new List<Claim>
+        {
+            new(JwtRegisteredClaimNames.Sub, user.UserId.ToString()),
+            new("role", user.Role.ToString())
+        };
+
+        var token = new JwtSecurityToken(
+            issuer: JwtIssuer,
+            audience: JwtAudience,
+            claims: claims,
+            expires: DateTime.UtcNow.AddHours(1),
+            signingCredentials: credentials);
+
+        return new JwtSecurityTokenHandler().WriteToken(token);
+    }
+}

--- a/Backend.Tests.Unit/Features/Users/UsersControllerTests.cs
+++ b/Backend.Tests.Unit/Features/Users/UsersControllerTests.cs
@@ -1,4 +1,5 @@
-﻿using Backend.Features.Users;
+﻿using Backend.Features.Auth;
+using Backend.Features.Users;
 using Microsoft.AspNetCore.Mvc;
 using NSubstitute;
 
@@ -6,6 +7,9 @@ namespace Backend.Tests.Unit.Features.Users;
 
 public class UsersControllerTests
 {
+    private static UsersController CreateController(IUserService userService)
+        => new(userService, Substitute.For<ICurrentUserContext>());
+
     [Fact]
     public async Task GetUser_WhenServiceThrowsKeyNotFoundException_ReturnsNotFound()
     {
@@ -14,7 +18,7 @@ public class UsersControllerTests
         userService.GetUserAsync(userId)
             .Returns(Task.FromException<UserWithVehiclesDto>(new KeyNotFoundException("not found")));
 
-        var controller = new UsersController(userService);
+        var controller = CreateController(userService);
         var result = await controller.GetUser(userId);
 
         Assert.IsType<NotFoundResult>(result.Result);
@@ -30,7 +34,7 @@ public class UsersControllerTests
         var userService = Substitute.For<IUserService>();
         userService.GetUserAsync(userId).Returns(expected);
 
-        var controller = new UsersController(userService);
+        var controller = CreateController(userService);
         var result = await controller.GetUser(userId);
 
         var ok = Assert.IsType<OkObjectResult>(result.Result);
@@ -52,7 +56,7 @@ public class UsersControllerTests
         userService.UpdateUserAsync(userId, Arg.Any<UpdateUserDto>())
             .Returns(Task.FromException<UserDto>(new KeyNotFoundException("not found")));
 
-        var controller = new UsersController(userService);
+        var controller = CreateController(userService);
         var result = await controller.UpdateUser(userId, dto);
 
         Assert.IsType<NotFoundResult>(result);
@@ -68,7 +72,7 @@ public class UsersControllerTests
         userService.UpdateUserAsync(userId, Arg.Any<UpdateUserDto>())
             .Returns(Task.FromResult(new UserDto { UserId = userId, Name = dto.Name ?? "existing", Email = dto.Email ?? "existing@email.com", Role = UserRole.Admin }));
 
-        var controller = new UsersController(userService);
+        var controller = CreateController(userService);
         var result = await controller.UpdateUser(userId, dto);
 
         Assert.IsType<OkObjectResult>(result);
@@ -84,7 +88,7 @@ public class UsersControllerTests
              new() { UserId = Guid.NewGuid(), Name = "Bob", Email = "bob@example.com", Role = UserRole.Admin }
         ]);
 
-        var controller = new UsersController(userService);
+        var controller = CreateController(userService);
         var result = await controller.GetAllUsers();
 
         var ok = Assert.IsType<OkObjectResult>(result.Result);
@@ -101,7 +105,7 @@ public class UsersControllerTests
         var userService = Substitute.For<IUserService>();
         userService.CreateUserAsync(Arg.Any<CreateUserDto>()).Returns(created);
 
-        var controller = new UsersController(userService);
+        var controller = CreateController(userService);
         var result = await controller.CreateUser(dto);
 
         Assert.IsType<CreatedAtActionResult>(result.Result);
@@ -116,7 +120,7 @@ public class UsersControllerTests
         userService.CreateUserAsync(Arg.Any<CreateUserDto>())
             .Returns(Task.FromException<UserDto>(new EmailAlreadyExistsException(dto.Email)));
 
-        var controller = new UsersController(userService);
+        var controller = CreateController(userService);
         var result = await controller.CreateUser(dto);
 
         Assert.IsType<ConflictObjectResult>(result.Result);
@@ -129,7 +133,7 @@ public class UsersControllerTests
         var userService = Substitute.For<IUserService>();
         userService.DeleteUserAsync(userId).Returns(Task.CompletedTask);
 
-        var controller = new UsersController(userService);
+        var controller = CreateController(userService);
         var result = await controller.DeleteUser(userId);
 
         Assert.IsType<NoContentResult>(result);
@@ -143,7 +147,7 @@ public class UsersControllerTests
         userService.DeleteUserAsync(userId)
             .Returns(Task.FromException(new KeyNotFoundException()));
 
-        var controller = new UsersController(userService);
+        var controller = CreateController(userService);
         var result = await controller.DeleteUser(userId);
 
         Assert.IsType<NotFoundResult>(result);
@@ -156,7 +160,7 @@ public class UsersControllerTests
         userService.GetUserByNameAsync("Alice")
             .Returns(new UserWithVehiclesDto { UserId = Guid.NewGuid(), Name = "Alice", Email = "alice@example.com", Role = UserRole.Admin });
 
-        var controller = new UsersController(userService);
+        var controller = CreateController(userService);
         var result = await controller.GetUserByName("Alice");
 
         Assert.IsType<OkObjectResult>(result.Result);
@@ -169,7 +173,7 @@ public class UsersControllerTests
         userService.GetUserByNameAsync("Inexistente")
             .Returns(Task.FromException<UserWithVehiclesDto>(new KeyNotFoundException()));
 
-        var controller = new UsersController(userService);
+        var controller = CreateController(userService);
         var result = await controller.GetUserByName("Inexistente");
 
         Assert.IsType<NotFoundResult>(result.Result);


### PR DESCRIPTION
Melhora a autenticação em todas as features.

- `Users`
  - Criação de usuário pública para clientes, admins podem criar outros admins
  - GET, PATCH e DELETE restritos para o usuário logado se for cliente, sem limitação para admins
- `Tags`: CRUD para admins, restrito para clientes
- `Dashboard`: Leitura para admins, restrito para clientes
- `ParkingPrices`: Leitura pública, atualização para admins


Foi criado um helper `AuthTestHelper` para facilitar testes de integração com usuários admin e clientes.