### PR TITLE
feat: seed de dados

### DIFF
--- a/Backend.API/Database/Seeding/AppSeeder.cs
+++ b/Backend.API/Database/Seeding/AppSeeder.cs
@@ -1,0 +1,170 @@
+using Backend.Features.Accesses;
+using Backend.Features.ParkingPrices;
+using Backend.Features.Tags;
+using Backend.Features.Tags.Enums;
+using Backend.Features.Transactions;
+using Backend.Features.Users;
+using Backend.Features.Vehicles;
+using Microsoft.EntityFrameworkCore;
+
+namespace Backend.Database.Seeding;
+
+public class AppSeeder(AppDbContext db, ILogger<AppSeeder> logger) : IAppSeeder
+{
+    private readonly AppDbContext _db = db;
+    private readonly ILogger<AppSeeder> _logger = logger;
+
+    public async Task<SeedExecutionResult> SeedAsync(CancellationToken cancellationToken = default)
+    {
+        if (await DatabaseHasAnyDataAsync(cancellationToken))
+        {
+            const string message = "Seeding skipped: database already contains data.";
+            _logger.LogInformation(message);
+            return SeedExecutionResult.SkippedExecution(message);
+        }
+
+        await using var transaction = await _db.Database.BeginTransactionAsync(cancellationToken);
+
+        var now = DateTime.UtcNow;
+
+        var adminUser = new User
+        {
+            Name = "Admin",
+            Email = "admin@email.com",
+            PasswordHash = BCrypt.Net.BCrypt.HashPassword("password"),
+            Role = UserRole.Admin,
+            Cpf = "11111111111",
+            Cellphone = "+5551999999999"
+        };
+
+        var customerUser = new User
+        {
+            Name = "Customer",
+            Email = "customer@email.com",
+            PasswordHash = BCrypt.Net.BCrypt.HashPassword("password"),
+            Role = UserRole.Customer,
+            Cpf = "22222222222",
+            Cellphone = "+5551888888888"
+        };
+
+        _db.Users.AddRange(adminUser, customerUser);
+        await _db.SaveChangesAsync(cancellationToken);
+
+        var primaryTag = new Tag
+        {
+            Epc = "E2000017221101441890ABCD",
+            Tid = "TID-0001",
+            Status = TagStatus.IN_USE
+        };
+
+        var secondaryTag = new Tag
+        {
+            Epc = "E2000017221101441890DCBA",
+            Tid = "TID-0002",
+            Status = TagStatus.IN_USE
+        };
+
+        _db.Tags.AddRange(primaryTag, secondaryTag);
+        await _db.SaveChangesAsync(cancellationToken);
+
+        var adminVehicle = new Vehicle
+        {
+            UserId = adminUser.UserId,
+            TagId = primaryTag.TagId,
+            Plate = "AAA1A11",
+            Brand = "Toyota",
+            Model = "Corolla"
+        };
+
+        var customerVehicle = new Vehicle
+        {
+            UserId = customerUser.UserId,
+            TagId = secondaryTag.TagId,
+            Plate = "BBB2B22",
+            Brand = "Honda",
+            Model = "Civic"
+        };
+
+        _db.Vehicles.AddRange(adminVehicle, customerVehicle);
+        await _db.SaveChangesAsync(cancellationToken);
+
+        var defaultPricing = new ParkingPrice
+        {
+            ToleranceMinutes = 15,
+            BasePrice = 15m,
+            HourlyRate = 5m,
+            ThresholdMinutes = 180
+        };
+
+        _db.ParkingPrices.Add(defaultPricing);
+        await _db.SaveChangesAsync(cancellationToken);
+
+        var accessEntry = new Access
+        {
+            TagId = primaryTag.TagId,
+            Tag = primaryTag,
+            Type = AccessType.Entry,
+            Timestamp = now.AddMinutes(-30)
+        };
+
+        var accessExit = new Access
+        {
+            TagId = primaryTag.TagId,
+            Tag = primaryTag,
+            Type = AccessType.Exit,
+            Timestamp = now
+        };
+
+        _db.Accesses.AddRange(accessEntry, accessExit);
+        await _db.SaveChangesAsync(cancellationToken);
+
+        var depositTransaction = new Transaction
+        {
+            TransactionId = Guid.NewGuid(),
+            UserId = customerUser.UserId,
+            AccessId = accessEntry.AccessId,
+            Amount = 100m,
+            Description = "Initial wallet deposit",
+            TransactionType = TransactionType.DEPOSIT
+        };
+
+        var withdrawalTransaction = new Transaction
+        {
+            TransactionId = Guid.NewGuid(),
+            UserId = customerUser.UserId,
+            AccessId = accessExit.AccessId,
+            Amount = 15m,
+            Description = "Parking payment",
+            TransactionType = TransactionType.WITHDRAWAL
+        };
+
+        _db.Transactions.AddRange(depositTransaction, withdrawalTransaction);
+        await _db.SaveChangesAsync(cancellationToken);
+
+        await transaction.CommitAsync(cancellationToken);
+
+        const string successMessage = "Seeding completed successfully.";
+        _logger.LogInformation(successMessage);
+
+        return new SeedExecutionResult
+        {
+            Message = successMessage,
+            UsersSeeded = 2,
+            TagsSeeded = 2,
+            VehiclesSeeded = 2,
+            ParkingPricesSeeded = 1,
+            AccessesSeeded = 2,
+            TransactionsSeeded = 2
+        };
+    }
+
+    private async Task<bool> DatabaseHasAnyDataAsync(CancellationToken cancellationToken)
+    {
+        return await _db.Users.AnyAsync(cancellationToken)
+            || await _db.Vehicles.AnyAsync(cancellationToken)
+            || await _db.Tags.AnyAsync(cancellationToken)
+            || await _db.ParkingPrices.AnyAsync(cancellationToken)
+            || await _db.Transactions.AnyAsync(cancellationToken)
+            || await _db.Accesses.AnyAsync(cancellationToken);
+    }
+}

--- a/Backend.API/Database/Seeding/AppSeeder.cs
+++ b/Backend.API/Database/Seeding/AppSeeder.cs
@@ -39,8 +39,8 @@ public class AppSeeder(AppDbContext db, ILogger<AppSeeder> logger) : IAppSeeder
 
         var customerUser = new User
         {
-            Name = "Customer",
-            Email = "customer@email.com",
+            Name = "Cliente",
+            Email = "cliente@email.com",
             PasswordHash = BCrypt.Net.BCrypt.HashPassword("password"),
             Role = UserRole.Customer,
             Cpf = "22222222222",

--- a/Backend.API/Database/Seeding/IAppSeeder.cs
+++ b/Backend.API/Database/Seeding/IAppSeeder.cs
@@ -1,0 +1,6 @@
+namespace Backend.Database.Seeding;
+
+public interface IAppSeeder
+{
+    Task<SeedExecutionResult> SeedAsync(CancellationToken cancellationToken = default);
+}

--- a/Backend.API/Database/Seeding/SeedExecutionResult.cs
+++ b/Backend.API/Database/Seeding/SeedExecutionResult.cs
@@ -1,0 +1,20 @@
+namespace Backend.Database.Seeding;
+
+public sealed class SeedExecutionResult
+{
+    public bool Skipped { get; init; }
+    public string Message { get; init; } = string.Empty;
+
+    public int UsersSeeded { get; init; }
+    public int VehiclesSeeded { get; init; }
+    public int TagsSeeded { get; init; }
+    public int ParkingPricesSeeded { get; init; }
+    public int TransactionsSeeded { get; init; }
+    public int AccessesSeeded { get; init; }
+
+    public static SeedExecutionResult SkippedExecution(string message) => new()
+    {
+        Skipped = true,
+        Message = message
+    };
+}

--- a/Backend.API/Program.cs
+++ b/Backend.API/Program.cs
@@ -7,6 +7,7 @@ using Microsoft.IdentityModel.Tokens;
 using Microsoft.OpenApi;
 
 using Backend.Database;
+using Backend.Database.Seeding;
 using Backend.Configuration;
 using Backend.Features.Tags;
 using Backend.Features.Auth;
@@ -102,6 +103,7 @@ builder.Services.AddScoped<ITransactionService, TransactionService>();
 builder.Services.AddScoped<IDashboardService, DashboardService>();
 builder.Services.AddScoped<IAccessesService, AccessesService>();
 builder.Services.AddScoped<IParkingPricesService, ParkingPricesService>();
+builder.Services.AddScoped<IAppSeeder, AppSeeder>();
 
 // Configure JWT Authentication
 var jwtSettings = builder.Configuration.GetSection("Jwt").Get<JwtSettings>()
@@ -143,6 +145,15 @@ if (!app.Environment.IsEnvironment("Testing") && !skipMigrations)
         var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
         db.Database.Migrate();
     }
+}
+
+// Seed initial data
+var skipSeeding = string.Equals(Environment.GetEnvironmentVariable("SKIP_SEEDING"), "true", StringComparison.OrdinalIgnoreCase);
+if (!skipSeeding)
+{
+    using var scope = app.Services.CreateScope();
+    var seeder = scope.ServiceProvider.GetRequiredService<IAppSeeder>();
+    await seeder.SeedAsync();
 }
 
 // Configure the HTTP request pipeline

--- a/Backend.Tests.Integration/Database/Seeding/AppSeederTests.cs
+++ b/Backend.Tests.Integration/Database/Seeding/AppSeederTests.cs
@@ -1,0 +1,66 @@
+using Backend.Database;
+using Backend.Database.Seeding;
+using Backend.Features.Users;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.EntityFrameworkCore;
+using tests.Setup;
+
+namespace Backend.Tests.Integration.Database.Seeding;
+
+public class AppSeederTests(CustomWebApplicationFactory factory) : IClassFixture<CustomWebApplicationFactory>, IAsyncLifetime
+{
+    private readonly CustomWebApplicationFactory _factory = factory;
+    private readonly IServiceScopeFactory _scopeFactory = factory.Services.GetRequiredService<IServiceScopeFactory>();
+
+    public async Task InitializeAsync()
+    {
+        await _factory.ResetDatabaseAsync();
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Fact]
+    public async Task SeedAsync_WhenDatabaseIsEmpty_ShouldSeedAllTables()
+    {
+        using var scope = _scopeFactory.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        var seeder = scope.ServiceProvider.GetRequiredService<IAppSeeder>();
+
+        var result = await seeder.SeedAsync();
+
+        Assert.False(result.Skipped);
+        Assert.True(await db.Users.AnyAsync());
+        Assert.True(await db.Vehicles.AnyAsync());
+        Assert.True(await db.Tags.AnyAsync());
+        Assert.True(await db.ParkingPrices.AnyAsync());
+        Assert.True(await db.Transactions.AnyAsync());
+        Assert.True(await db.Accesses.AnyAsync());
+    }
+
+    [Fact]
+    public async Task SeedAsync_WhenAnyTableHasData_ShouldSkipEntireSeeding()
+    {
+        using var scope = _scopeFactory.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        var seeder = scope.ServiceProvider.GetRequiredService<IAppSeeder>();
+
+        db.Users.Add(new User
+        {
+            Name = "PreExisting",
+            Email = "preexisting@backend.local",
+            PasswordHash = "hash",
+            Role = UserRole.Admin
+        });
+        await db.SaveChangesAsync();
+
+        var result = await seeder.SeedAsync();
+
+        Assert.True(result.Skipped);
+        Assert.Equal(1, await db.Users.CountAsync());
+        Assert.Equal(0, await db.Vehicles.CountAsync());
+        Assert.Equal(0, await db.Tags.CountAsync());
+        Assert.Equal(0, await db.ParkingPrices.CountAsync());
+        Assert.Equal(0, await db.Transactions.CountAsync());
+        Assert.Equal(0, await db.Accesses.CountAsync());
+    }
+}

--- a/Backend.Tests.Integration/Setup/CustomWebApplicationFactory.cs
+++ b/Backend.Tests.Integration/Setup/CustomWebApplicationFactory.cs
@@ -22,6 +22,7 @@ public class CustomWebApplicationFactory : WebApplicationFactory<Program>, IAsyn
     public CustomWebApplicationFactory()
     {
         Environment.SetEnvironmentVariable("SKIP_MIGRATIONS", "true");
+        Environment.SetEnvironmentVariable("SKIP_SEEDING", "true");
     }
 
     // Define the PostgreSQL container

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ docker compose --profile full up -d --build
 ```
 
 ### Migrações e Seed
+
 As migrações do banco de dados ficam armazenadas em `Backend.API/Database/Migrations`, e são aplicadas automáticamente na inicialização da aplicação.
 
 Para criar uma nova migração, altere os modelos e execute o comando:
@@ -53,6 +54,7 @@ Para criar uma nova migração, altere os modelos e execute o comando:
 > NOTA: É necessário instalar a CLI do Entity Framework Core globalmente para rodar o comando abaixo:
 >
 > Caso já tenha a CLI instalada, não é necessário rodar o comando novamente.
+>
 > ```bash
 > dotnet tool install --global dotnet-ef
 > ```
@@ -61,6 +63,33 @@ Para criar uma nova migração, altere os modelos e execute o comando:
 dotnet ef migrations add NomeDaMigracao --project Backend.API/ --output-dir Database/Migrations
 ```
 
+O seed também é executado roda automaticamente na inicialização, após as migrações. Ele só é aplicado se não houver dados nas tabelas do banco.
+
+Você pode desativar o seed com a variável de ambiente:
+
+```bash
+SKIP_SEEDING=true
+```
+
+Os usuários inseridos pelo seed são:
+
+| Tipo    | Email             | Senha    |
+| ------- | ----------------- | -------- |
+| Admin   | admin@email.com   | password |
+| Cliente | cliente@email.com | password |
+
+#### Já tenho dados no banco. E agora?
+
+Se o seu banco já possui dados, o seed não vai rodar (comportamento esperado).
+
+Se você quiser rodar o seed novamente, você precisa excluir os dados já existentes:
+
+```bash
+docker compose down -v
+docker compose up -d
+```
+
+Depois disso, reinicie a API para o seed executar novamente.
 
 ## Testes
 


### PR DESCRIPTION
Adiciona um seeder para dados de teste/desenvolvimento. Cria usuários, veículos, tags, transações, acessos e a tabela de preço padrão. Não roda se já existem dados para garantir consistência. Pode ser desabilitado com a flag `SKIP_SEEDING=true`.