### PR TITLE
feat: add GET /api/dashboard/peak-hours endpoint

### DIFF
--- a/Backend.API/Features/Dashboard/DashboardController.cs
+++ b/Backend.API/Features/Dashboard/DashboardController.cs
@@ -36,4 +36,18 @@ public class DashboardController(IDashboardService dashboardService) : Controlle
             return Problem();
         }
     }
+
+    [HttpGet("peak-hours")]
+    public async Task<ActionResult<PeakHoursDto>> GetPeakHours()
+    {
+        try
+        {
+            var peakHours = await _dashboardService.GetPeakHoursAsync();
+            return Ok(peakHours);
+        }
+        catch (Exception)
+        {
+            return Problem();
+        }
+    }
 }

--- a/Backend.API/Features/Dashboard/DashboardService.cs
+++ b/Backend.API/Features/Dashboard/DashboardService.cs
@@ -9,6 +9,7 @@ public interface IDashboardService
 {
     Task<OccupancyDto> GetOccupancyAsync();
     Task<DashboardMetricsDto> GetMetricsAsync();
+    Task<PeakHoursDto> GetPeakHoursAsync();
 }
 
 public class DashboardService(AppDbContext db) : IDashboardService
@@ -62,6 +63,26 @@ public class DashboardService(AppDbContext db) : IDashboardService
             PeakEntryTime = peakEntryTime == 0 && entriesLastHour == 0
                 ? null
                 : $"{peakEntryTime:D2}:00"
+        };
+    }
+
+    public async Task<PeakHoursDto> GetPeakHoursAsync()
+    {
+        var now = DateTime.UtcNow;
+        var twentyFourHoursAgo = now.AddHours(-24);
+
+        var top = await _db.Accesses
+            .AsNoTracking()
+            .Where(a => a.Type == AccessType.Entry && a.Timestamp >= twentyFourHoursAgo)
+            .GroupBy(a => a.Timestamp.Hour)
+            .Select(g => new { Hour = g.Key, Count = g.Count() })
+            .OrderByDescending(g => g.Count)
+            .FirstOrDefaultAsync();
+
+        return new PeakHoursDto
+        {
+            PeakHour = top != null ? $"{top.Hour:D2}:00" : null,
+            Entries = top?.Count ?? 0
         };
     }
 }

--- a/Backend.API/Features/Dashboard/Dtos/PeakHoursDto.cs
+++ b/Backend.API/Features/Dashboard/Dtos/PeakHoursDto.cs
@@ -1,0 +1,8 @@
+namespace Backend.Features.Dashboard;
+
+public class PeakHoursDto
+{
+    public string? PeakHour { get; set; }
+    public int Entries { get; set; }
+    public string Range { get; set; } = "Last 24 hours";
+}

--- a/Backend.Tests.Integration/Features/Dashboard/DashboardControllerTests.cs
+++ b/Backend.Tests.Integration/Features/Dashboard/DashboardControllerTests.cs
@@ -200,4 +200,69 @@ public class DashboardControllerTests(CustomWebApplicationFactory factory)
         Assert.True(metrics.EntriesLastHour >= 0);
         Assert.True(metrics.ExitsLastHour >= 0);
     }
+
+    [Fact]
+    public async Task GetPeakHours_WhenNoEntries_ReturnsNullPeakHourAndZeroEntries()
+    {
+        var response = await _client.GetAsync("/api/dashboard/peak-hours");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var body = await response.Content.ReadFromJsonAsync<PeakHoursDto>(
+            CustomWebApplicationFactory.JsonOptions);
+
+        Assert.NotNull(body);
+        Assert.Null(body.PeakHour);
+        Assert.Equal(0, body.Entries);
+        Assert.Equal("Last 24 hours", body.Range);
+    }
+
+    [Fact]
+    public async Task GetPeakHours_WhenEntriesExist_ReturnsPeakHourWithMostEntries()
+    {
+        var (_, _, tagA) = await SeedVehicleWithTagAsync("PEAK-A");
+        var (_, _, tagB) = await SeedVehicleWithTagAsync("PEAK-B");
+        var now = DateTime.UtcNow;
+        var peakTime = new DateTime(now.Year, now.Month, now.Day, now.Hour, 0, 0, DateTimeKind.Utc).AddHours(-2);
+
+        // 3 entries at peakTime's hour
+        await SeedAccessAsync(tagA.TagId, AccessType.Entry, peakTime);
+        await SeedAccessAsync(tagA.TagId, AccessType.Entry, peakTime.AddMinutes(10));
+        await SeedAccessAsync(tagB.TagId, AccessType.Entry, peakTime.AddMinutes(20));
+        // 1 entry at a different hour
+        await SeedAccessAsync(tagB.TagId, AccessType.Entry, now.AddHours(-1));
+
+        var response = await _client.GetAsync("/api/dashboard/peak-hours");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var body = await response.Content.ReadFromJsonAsync<PeakHoursDto>(
+            CustomWebApplicationFactory.JsonOptions);
+
+        Assert.NotNull(body);
+        Assert.Equal($"{peakTime.Hour:D2}:00", body.PeakHour);
+        Assert.Equal(3, body.Entries);
+        Assert.Equal("Last 24 hours", body.Range);
+    }
+
+    [Fact]
+    public async Task GetPeakHours_ExitsAreNotCounted()
+    {
+        var (_, _, tag) = await SeedVehicleWithTagAsync("EXIT-ONLY");
+        var now = DateTime.UtcNow;
+
+        await SeedAccessAsync(tag.TagId, AccessType.Exit, now.AddMinutes(-30));
+        await SeedAccessAsync(tag.TagId, AccessType.Exit, now.AddMinutes(-20));
+
+        var response = await _client.GetAsync("/api/dashboard/peak-hours");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var body = await response.Content.ReadFromJsonAsync<PeakHoursDto>(
+            CustomWebApplicationFactory.JsonOptions);
+
+        Assert.NotNull(body);
+        Assert.Null(body.PeakHour);
+        Assert.Equal(0, body.Entries);
+    }
 }

--- a/Backend.Tests.Unit/Features/Dashboard/DashboardControllerTests.cs
+++ b/Backend.Tests.Unit/Features/Dashboard/DashboardControllerTests.cs
@@ -148,4 +148,76 @@ public class DashboardControllerTests
         Assert.Equal(0, dto.ExitsLastHour);
         Assert.Null(dto.PeakEntryTime);
     }
+
+    [Fact]
+    public async Task GetPeakHours_WhenServiceSucceeds_ReturnsOk()
+    {
+        var expected = new PeakHoursDto { PeakHour = "14:00", Entries = 32 };
+
+        var service = Substitute.For<IDashboardService>();
+        service.GetPeakHoursAsync().Returns(expected);
+
+        var controller = new DashboardController(service);
+        var result = await controller.GetPeakHours();
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        var dto = Assert.IsType<PeakHoursDto>(ok.Value);
+        Assert.Equal("14:00", dto.PeakHour);
+        Assert.Equal(32, dto.Entries);
+    }
+
+    [Fact]
+    public async Task GetPeakHours_WhenServiceSucceeds_ReturnsStatusCode200()
+    {
+        var service = Substitute.For<IDashboardService>();
+        service.GetPeakHoursAsync().Returns(new PeakHoursDto());
+
+        var controller = new DashboardController(service);
+        var result = await controller.GetPeakHours();
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        Assert.Equal(200, ok.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetPeakHours_WhenServiceSucceeds_CallsServiceExactlyOnce()
+    {
+        var service = Substitute.For<IDashboardService>();
+        service.GetPeakHoursAsync().Returns(new PeakHoursDto());
+
+        var controller = new DashboardController(service);
+        await controller.GetPeakHours();
+
+        await service.Received(1).GetPeakHoursAsync();
+    }
+
+    [Fact]
+    public async Task GetPeakHours_WhenServiceThrows_Returns500()
+    {
+        var service = Substitute.For<IDashboardService>();
+        service.GetPeakHoursAsync().ThrowsAsync(new Exception("db error"));
+
+        var controller = new DashboardController(service);
+        var result = await controller.GetPeakHours();
+
+        var status = Assert.IsType<ObjectResult>(result.Result);
+        Assert.Equal(500, status.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetPeakHours_WhenNoEntries_ReturnsPeakHourNull()
+    {
+        var expected = new PeakHoursDto { PeakHour = null, Entries = 0 };
+
+        var service = Substitute.For<IDashboardService>();
+        service.GetPeakHoursAsync().Returns(expected);
+
+        var controller = new DashboardController(service);
+        var result = await controller.GetPeakHours();
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        var dto = Assert.IsType<PeakHoursDto>(ok.Value);
+        Assert.Null(dto.PeakHour);
+        Assert.Equal(0, dto.Entries);
+    }
 }

--- a/Backend.Tests.Unit/Features/Dashboard/DashboardServiceTests.cs
+++ b/Backend.Tests.Unit/Features/Dashboard/DashboardServiceTests.cs
@@ -123,4 +123,74 @@ public class DashboardServiceTests
 
         Assert.Null(result.PeakEntryTime);
     }
+
+    [Fact]
+    public async Task GetPeakHoursAsync_WhenNoEntriesInLast24h_ReturnsPeakHourNullAndZeroEntries()
+    {
+        var db = CreateInMemoryDb();
+        var service = new DashboardService(db);
+
+        var result = await service.GetPeakHoursAsync();
+
+        Assert.Null(result.PeakHour);
+        Assert.Equal(0, result.Entries);
+        Assert.Equal("Last 24 hours", result.Range);
+    }
+
+    [Fact]
+    public async Task GetPeakHoursAsync_WhenEntriesExist_ReturnsPeakHourWithHighestCount()
+    {
+        var db = CreateInMemoryDb();
+        var now = DateTime.UtcNow;
+        // two entries at hour H-2, one entry at H-1
+        var peakTime = new DateTime(now.Year, now.Month, now.Day, now.Hour, 0, 0, DateTimeKind.Utc).AddHours(-2);
+
+        db.Accesses.Add(CreateAccess(Guid.NewGuid(), AccessType.Entry, peakTime));
+        db.Accesses.Add(CreateAccess(Guid.NewGuid(), AccessType.Entry, peakTime.AddMinutes(15)));
+        db.Accesses.Add(CreateAccess(Guid.NewGuid(), AccessType.Entry, now.AddHours(-1)));
+        await db.SaveChangesAsync();
+
+        var service = new DashboardService(db);
+        var result = await service.GetPeakHoursAsync();
+
+        Assert.Equal($"{peakTime.Hour:D2}:00", result.PeakHour);
+        Assert.Equal(2, result.Entries);
+        Assert.Equal("Last 24 hours", result.Range);
+    }
+
+    [Fact]
+    public async Task GetPeakHoursAsync_ExitsAreIgnored()
+    {
+        var db = CreateInMemoryDb();
+        var now = DateTime.UtcNow;
+
+        db.Accesses.Add(CreateAccess(Guid.NewGuid(), AccessType.Exit, now.AddMinutes(-10)));
+        db.Accesses.Add(CreateAccess(Guid.NewGuid(), AccessType.Exit, now.AddMinutes(-20)));
+        await db.SaveChangesAsync();
+
+        var service = new DashboardService(db);
+        var result = await service.GetPeakHoursAsync();
+
+        Assert.Null(result.PeakHour);
+        Assert.Equal(0, result.Entries);
+        Assert.Equal("Last 24 hours", result.Range);
+    }
+
+    [Fact]
+    public async Task GetPeakHoursAsync_EntriesOlderThan24h_AreIgnored()
+    {
+        var db = CreateInMemoryDb();
+        var now = DateTime.UtcNow;
+
+        db.Accesses.Add(CreateAccess(Guid.NewGuid(), AccessType.Entry, now.AddHours(-25)));
+        db.Accesses.Add(CreateAccess(Guid.NewGuid(), AccessType.Entry, now.AddHours(-48)));
+        await db.SaveChangesAsync();
+
+        var service = new DashboardService(db);
+        var result = await service.GetPeakHoursAsync();
+
+        Assert.Null(result.PeakHour);
+        Assert.Equal(0, result.Entries);
+        Assert.Equal("Last 24 hours", result.Range);
+    }
 }


### PR DESCRIPTION
## Summary

- Adds `GET /api/dashboard/peak-hours` to the Dashboard feature to support the "Horário com mais entradas" component
- Returns the hour with the most vehicle entries in the last 24 hours, dynamically calculated from the `Accesses` table
- Extends the existing Dashboard vertical slice (new DTO + service method + controller action)

## Changes

- `Backend.API/Features/Dashboard/Dtos/PeakHoursDto.cs` — new DTO (`PeakHour`, `Entries`, `Range`)
- `Backend.API/Features/Dashboard/DashboardService.cs` — `GetPeakHoursAsync()` added to interface and implementation
- `Backend.API/Features/Dashboard/DashboardController.cs` — `GET /api/dashboard/peak-hours` action

## Test plan

- [x] 4 unit tests for `DashboardService.GetPeakHoursAsync` (empty DB, peak selection, exits ignored, old entries ignored)
- [x] 5 unit tests for `DashboardController.GetPeakHours` (200 OK, status code, service called once, 500 on exception, null peak hour)
- [x] 3 integration tests against real PostgreSQL via Testcontainers (no entries, entries with clear peak, exits not counted)
- [x] 125 unit tests passing
- [x] 113 integration tests passing

Closes #87