### PR TITLE
feat: consolidated GET /api/dashboard endpoint

### DIFF
--- a/Backend.API/Features/Dashboard/DashboardController.cs
+++ b/Backend.API/Features/Dashboard/DashboardController.cs
@@ -38,4 +38,18 @@ public class DashboardController(IDashboardService dashboardService) : Controlle
             return Problem();
         }
     }
+
+    [HttpGet]
+    public async Task<ActionResult<DashboardMetricsDto>> GetDashboard()
+    {
+        try
+        {
+            var dashboard = await _dashboardService.GetDashboardAsync();
+            return Ok(dashboard);
+        }
+        catch (Exception)
+        {
+            return Problem();
+        }
+    }
 }

--- a/Backend.API/Features/Dashboard/DashboardService.cs
+++ b/Backend.API/Features/Dashboard/DashboardService.cs
@@ -83,25 +83,19 @@ public class DashboardService(AppDbContext db, ISettingsService settingsService)
     {
         var now = DateTime.UtcNow;
         var twentyFourHoursAgo = now.AddHours(-24);
-
-        var metricsTask = GetMetricsAsync();
-        var occupancyTask = GetOccupancyAsync();
-        var accessesTask = _db.Accesses
+        var metrics = await GetMetricsAsync();
+        var occupancy = await GetOccupancyAsync();
+        var accesses = await _db.Accesses
             .AsNoTracking()
             .Where(a => a.Timestamp >= twentyFourHoursAgo)
             .OrderByDescending(a => a.Timestamp)
-            .Select(a => AccessDto.FromModel(a))
             .ToListAsync();
 
-        await Task.WhenAll(metricsTask, occupancyTask, accessesTask);
-
-        var metrics = await metricsTask;
-        var occupancy = await occupancyTask;
-        var accesses = await accessesTask;
+        var accessDtos = accesses.Select(AccessDto.FromModel).ToList();
 
         metrics.CurrentOccupancy = occupancy.CurrentOccupancy;
         metrics.MaxOccupancy = occupancy.MaxOccupancy;
-        metrics.Accesses = accesses;
+        metrics.Accesses = accessDtos;
         metrics.UpdatedAt = now;
 
         return metrics;

--- a/Backend.API/Features/Dashboard/DashboardService.cs
+++ b/Backend.API/Features/Dashboard/DashboardService.cs
@@ -106,4 +106,5 @@ public class DashboardService(AppDbContext db, ISettingsService settingsService)
 
         return metrics;
     }
+    }
 }

--- a/Backend.API/Features/Dashboard/DashboardService.cs
+++ b/Backend.API/Features/Dashboard/DashboardService.cs
@@ -106,5 +106,4 @@ public class DashboardService(AppDbContext db, ISettingsService settingsService)
 
         return metrics;
     }
-    }
 }

--- a/Backend.API/Features/Dashboard/DashboardService.cs
+++ b/Backend.API/Features/Dashboard/DashboardService.cs
@@ -10,6 +10,7 @@ public interface IDashboardService
 {
     Task<OccupancyDto> GetOccupancyAsync();
     Task<DashboardMetricsDto> GetMetricsAsync();
+    Task<DashboardMetricsDto> GetDashboardAsync();
 }
 
 public class DashboardService(AppDbContext db, ISettingsService settingsService) : IDashboardService
@@ -76,5 +77,33 @@ public class DashboardService(AppDbContext db, ISettingsService settingsService)
             PeakHourEntries = peakEntry?.Count ?? 0,
             MaxOccupancy = maxOccupancy
         };
+    }
+
+    public async Task<DashboardMetricsDto> GetDashboardAsync()
+    {
+        var now = DateTime.UtcNow;
+        var twentyFourHoursAgo = now.AddHours(-24);
+
+        var metricsTask = GetMetricsAsync();
+        var occupancyTask = GetOccupancyAsync();
+        var accessesTask = _db.Accesses
+            .AsNoTracking()
+            .Where(a => a.Timestamp >= twentyFourHoursAgo)
+            .OrderByDescending(a => a.Timestamp)
+            .Select(a => AccessDto.FromModel(a))
+            .ToListAsync();
+
+        await Task.WhenAll(metricsTask, occupancyTask, accessesTask);
+
+        var metrics = await metricsTask;
+        var occupancy = await occupancyTask;
+        var accesses = await accessesTask;
+
+        metrics.CurrentOccupancy = occupancy.CurrentOccupancy;
+        metrics.MaxOccupancy = occupancy.MaxOccupancy;
+        metrics.Accesses = accesses;
+        metrics.UpdatedAt = now;
+
+        return metrics;
     }
 }

--- a/Backend.API/Features/Dashboard/Dtos/DashboardMetricsDto.cs
+++ b/Backend.API/Features/Dashboard/Dtos/DashboardMetricsDto.cs
@@ -1,3 +1,5 @@
+using Backend.Features.Accesses;
+
 namespace Backend.Features.Dashboard;
 
 public class DashboardMetricsDto
@@ -6,5 +8,8 @@ public class DashboardMetricsDto
     public int ExitsLastHour { get; set; }
     public string? PeakEntryTime { get; set; }
     public int PeakHourEntries { get; set; }
+    public int CurrentOccupancy { get; set; }
     public int MaxOccupancy { get; set; }
+    public IEnumerable<AccessDto> Accesses { get; set; } = [];
+    public DateTime UpdatedAt { get; set; }
 }

--- a/Backend.Tests.Integration/Features/Dashboard/DashboardControllerTests.cs
+++ b/Backend.Tests.Integration/Features/Dashboard/DashboardControllerTests.cs
@@ -358,7 +358,7 @@ public class DashboardControllerTests(CustomWebApplicationFactory factory)
     public async Task GetMetrics_WithAccessesInPast24Hours_ReturnsPeakEntryTime()
     {
         var adminClient = await AuthTestHelper.CreateClientAsAsync(factory, UserRole.Admin);
-        var now = DateTime.UtcNow;
+        var now = new DateTime(2026, 6, 18, 14, 30, 0, DateTimeKind.Utc);
         var peakHour = now.AddHours(-5);
         var nonPeakHour = now.AddHours(-10);
 
@@ -377,7 +377,7 @@ public class DashboardControllerTests(CustomWebApplicationFactory factory)
         var metrics = await response.Content.ReadFromJsonAsync<DashboardMetricsDto>(CustomWebApplicationFactory.JsonOptions);
 
         Assert.NotNull(metrics);
-        Assert.Equal($"{peakHour.Hour:D2}:00", metrics.PeakEntryTime);
+        Assert.Equal("09:00", metrics.PeakEntryTime);
     }
 
     [Fact]

--- a/Backend.Tests.Integration/Features/Dashboard/DashboardControllerTests.cs
+++ b/Backend.Tests.Integration/Features/Dashboard/DashboardControllerTests.cs
@@ -398,6 +398,10 @@ public class DashboardControllerTests(CustomWebApplicationFactory factory)
         Assert.Equal(1, metrics.EntriesLastHour);
         Assert.Equal(0, metrics.ExitsLastHour);
         Assert.Equal(1, metrics.CurrentOccupancy);
+        Assert.Equal(100, metrics.MaxOccupancy);
+        Assert.Equal(1, metrics.PeakEntryHour);
+        Assert.Equal($"{baseTime.AddMinutes(-30).Hour:D2}:00", metrics.PeakEntryTime);
+        Assert.True(metrics.UpdatedAt > DateTime.MinValue);
         Assert.NotNull(metrics.Accesses);
         Assert.True(metrics.PeakHourEntries > 0);
         Assert.True(metrics.UpdatedAt > DateTime.MinValue);

--- a/Backend.Tests.Integration/Features/Dashboard/DashboardControllerTests.cs
+++ b/Backend.Tests.Integration/Features/Dashboard/DashboardControllerTests.cs
@@ -327,4 +327,80 @@ public class DashboardControllerTests(CustomWebApplicationFactory factory)
         Assert.NotNull(body);
         Assert.Equal(1.0, body.OccupancyPercentage);
     }
+
+    [Fact]
+    public async Task GetMetrics_WithEntriesAndExitsInLastHour_ReturnsCalculatedCounts()
+    {
+        var adminClient = await AuthTestHelper.CreateClientAsAsync(factory, UserRole.Admin);
+        var baseTime = DateTime.UtcNow;
+
+        var (_, _, entryTag1) = await SeedVehicleWithTagAsync("ENT-001");
+        var (_, _, entryTag2) = await SeedVehicleWithTagAsync("ENT-002");
+        var (_, _, exitTag) = await SeedVehicleWithTagAsync("EXT-001");
+
+        await SeedAccessAsync(entryTag1.TagId, AccessType.Entry, baseTime.AddMinutes(-45));
+        await SeedAccessAsync(entryTag2.TagId, AccessType.Entry, baseTime.AddMinutes(-20));
+        await SeedAccessAsync(exitTag.TagId, AccessType.Exit, baseTime.AddMinutes(-10));
+
+        await SeedAccessAsync(entryTag1.TagId, AccessType.Entry, baseTime.AddHours(-2));
+
+        var response = await adminClient.GetAsync("/api/dashboard/metrics");
+
+        response.EnsureSuccessStatusCode();
+        var metrics = await response.Content.ReadFromJsonAsync<DashboardMetricsDto>(CustomWebApplicationFactory.JsonOptions);
+
+        Assert.NotNull(metrics);
+        Assert.Equal(2, metrics.EntriesLastHour);
+        Assert.Equal(1, metrics.ExitsLastHour);
+    }
+
+    [Fact]
+    public async Task GetMetrics_WithAccessesInPast24Hours_ReturnsPeakEntryTime()
+    {
+        var adminClient = await AuthTestHelper.CreateClientAsAsync(factory, UserRole.Admin);
+        var now = DateTime.UtcNow;
+        var peakHour = now.AddHours(-5);
+        var nonPeakHour = now.AddHours(-10);
+
+        var (_, _, vehicleA) = await SeedVehicleWithTagAsync("PEAK-A");
+        var (_, _, vehicleB) = await SeedVehicleWithTagAsync("PEAK-B");
+
+        await SeedAccessAsync(vehicleA.TagId, AccessType.Entry, peakHour.AddMinutes(10));
+        await SeedAccessAsync(vehicleB.TagId, AccessType.Entry, peakHour.AddMinutes(20));
+        await SeedAccessAsync(vehicleA.TagId, AccessType.Entry, peakHour.AddMinutes(30));
+
+        await SeedAccessAsync(vehicleA.TagId, AccessType.Entry, nonPeakHour.AddMinutes(15));
+
+        var response = await adminClient.GetAsync("/api/dashboard/metrics");
+
+        response.EnsureSuccessStatusCode();
+        var metrics = await response.Content.ReadFromJsonAsync<DashboardMetricsDto>(CustomWebApplicationFactory.JsonOptions);
+
+        Assert.NotNull(metrics);
+        Assert.Equal($"{peakHour.Hour:D2}:00", metrics.PeakEntryTime);
+    }
+
+    [Fact]
+    public async Task GetDashboard_WhenCalled_ReturnsCombinedMetricsAndOccupancy()
+    {
+        var adminClient = await AuthTestHelper.CreateClientAsAsync(factory, UserRole.Admin);
+        var baseTime = DateTime.UtcNow;
+        var (_, _, vehicle) = await SeedVehicleWithTagAsync("AAA-999");
+
+        await SeedAccessAsync(vehicle.TagId, AccessType.Entry, baseTime.AddMinutes(-30));
+
+        var response = await adminClient.GetAsync("/api/dashboard");
+
+        response.EnsureSuccessStatusCode();
+        var metrics = await response.Content.ReadFromJsonAsync<DashboardMetricsDto>(CustomWebApplicationFactory.JsonOptions);
+
+        Assert.NotNull(metrics);
+        Assert.Equal(1, metrics.EntriesLastHour);
+        Assert.Equal(0, metrics.ExitsLastHour);
+        Assert.Equal(1, metrics.CurrentOccupancy);
+        Assert.NotNull(metrics.Accesses);
+        Assert.True(metrics.PeakHourEntries > 0);
+        Assert.True(metrics.UpdatedAt > DateTime.MinValue);
+        Assert.NotEmpty(metrics.Accesses);
+    }
 }

--- a/Backend.Tests.Integration/Features/Dashboard/DashboardControllerTests.cs
+++ b/Backend.Tests.Integration/Features/Dashboard/DashboardControllerTests.cs
@@ -358,9 +358,9 @@ public class DashboardControllerTests(CustomWebApplicationFactory factory)
     public async Task GetMetrics_WithAccessesInPast24Hours_ReturnsPeakEntryTime()
     {
         var adminClient = await AuthTestHelper.CreateClientAsAsync(factory, UserRole.Admin);
-        var now = new DateTime(2026, 6, 18, 14, 30, 0, DateTimeKind.Utc);
-        var peakHour = now.AddHours(-5);
-        var nonPeakHour = now.AddHours(-10);
+        var now = DateTime.UtcNow;
+        var peakHour = new DateTime(now.Year, now.Month, now.Day, now.Hour, 0, 0, DateTimeKind.Utc).AddHours(-5);
+        var nonPeakHour = peakHour.AddHours(-5);
 
         var (_, _, vehicleA) = await SeedVehicleWithTagAsync("PEAK-A");
         var (_, _, vehicleB) = await SeedVehicleWithTagAsync("PEAK-B");
@@ -377,7 +377,7 @@ public class DashboardControllerTests(CustomWebApplicationFactory factory)
         var metrics = await response.Content.ReadFromJsonAsync<DashboardMetricsDto>(CustomWebApplicationFactory.JsonOptions);
 
         Assert.NotNull(metrics);
-        Assert.Equal("09:00", metrics.PeakEntryTime);
+        Assert.Equal($"{peakHour.Hour:D2}:00", metrics.PeakEntryTime);
     }
 
     [Fact]
@@ -399,7 +399,7 @@ public class DashboardControllerTests(CustomWebApplicationFactory factory)
         Assert.Equal(0, metrics.ExitsLastHour);
         Assert.Equal(1, metrics.CurrentOccupancy);
         Assert.Equal(100, metrics.MaxOccupancy);
-        Assert.Equal(1, metrics.PeakEntryHour);
+        Assert.Equal(1, metrics.PeakHourEntries);
         Assert.Equal($"{baseTime.AddMinutes(-30).Hour:D2}:00", metrics.PeakEntryTime);
         Assert.True(metrics.UpdatedAt > DateTime.MinValue);
         Assert.NotNull(metrics.Accesses);

--- a/Backend.Tests.Unit/Features/Dashboard/DashboardControllerTests.cs
+++ b/Backend.Tests.Unit/Features/Dashboard/DashboardControllerTests.cs
@@ -195,4 +195,41 @@ public class DashboardControllerTests
         Assert.Equal(42, dto.PeakHourEntries);
         Assert.Equal("14:00", dto.PeakEntryTime);
     }
+    [Fact]
+    public async Task GetDashboard_WhenServiceSucceeds_ReturnsOkWithDashboardMetrics()
+    {
+        var expected = new DashboardMetricsDto
+        {
+            EntriesLastHour = 10,
+            PeakEntryHour = 5,
+            PeakEntryTime = "10:00",
+            UpdatedAt = DateTime.UtcNow
+        };
+
+        var service = Substitute.For<IDashboardService>();
+        service.GetDashboardAsync().Returns(expected);
+
+        var controller = new DashboardController(service);
+        var result = await controller.GetDashboard();
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        var dto = Assert.IsType<DashboardMetricsDto>(ok.Value);
+        Assert.Equal(10, dto.EntriesLastHour);
+        Assert.Equal(5, dto.PeakEntryHour);
+        Assert.Equal("10:00", dto.PeakEntryTime);
+        Assert.Equal(expected.UpdatedAt, dto.UpdatedAt);
+    }
+
+    [Fact]
+    public async Task GetDashboard_WhenServiceThrows_Returns500()
+    {
+        var service = Substitute.For<IDashboardService>();
+        service.GetDashboardAsync().ThrowsAsync(new Exception("db error"));
+
+        var controller = new DashboardController(service);
+        var result = await controller.GetDashboard();
+
+        var status = Assert.IsType<ObjectResult>(result.Result);
+        Assert.Equal(500, status.StatusCode);
+    }
 }

--- a/Backend.Tests.Unit/Features/Dashboard/DashboardControllerTests.cs
+++ b/Backend.Tests.Unit/Features/Dashboard/DashboardControllerTests.cs
@@ -201,7 +201,7 @@ public class DashboardControllerTests
         var expected = new DashboardMetricsDto
         {
             EntriesLastHour = 10,
-            PeakEntryHour = 5,
+            PeakHourEntries = 5,
             PeakEntryTime = "10:00",
             UpdatedAt = DateTime.UtcNow
         };
@@ -215,7 +215,7 @@ public class DashboardControllerTests
         var ok = Assert.IsType<OkObjectResult>(result.Result);
         var dto = Assert.IsType<DashboardMetricsDto>(ok.Value);
         Assert.Equal(10, dto.EntriesLastHour);
-        Assert.Equal(5, dto.PeakEntryHour);
+        Assert.Equal(5, dto.PeakHourEntries);
         Assert.Equal("10:00", dto.PeakEntryTime);
         Assert.Equal(expected.UpdatedAt, dto.UpdatedAt);
     }

--- a/Backend.Tests.Unit/Features/Dashboard/DashboardControllerTests.cs
+++ b/Backend.Tests.Unit/Features/Dashboard/DashboardControllerTests.cs
@@ -175,4 +175,24 @@ public class DashboardControllerTests
         var dto = Assert.IsType<DashboardMetricsDto>(ok.Value);
         Assert.Equal(150, dto.MaxOccupancy);
     }
+
+    [Fact]
+    public async Task GetMetrics_WhenServiceReturnsPeakOccupancy_ReturnsCorrectValue()
+    {
+        var expected = new DashboardMetricsDto
+        {
+            PeakHourEntries = 42,
+            PeakEntryTime = "14:00"
+        };
+        var service = Substitute.For<IDashboardService>();
+        service.GetMetricsAsync().Returns(expected);
+        var controller = new DashboardController(service);
+
+        var result = await controller.GetMetrics();
+
+        var okResult = Assert.IsType<OkObjectResult>(result.Result);
+        var dto = Assert.IsType<DashboardMetricsDto>(okResult.Value);
+        Assert.Equal(42, dto.PeakHourEntries);
+        Assert.Equal("14:00", dto.PeakEntryTime);
+    }
 }

--- a/Backend.Tests.Unit/Features/Dashboard/DashboardServiceTests.cs
+++ b/Backend.Tests.Unit/Features/Dashboard/DashboardServiceTests.cs
@@ -156,7 +156,7 @@ public class DashboardServiceTests
         Assert.Equal(100, result.MaxOccupancy);
     }
 
-    // GetOccupancyAsync
+
 
     private static async Task<(Guid tagId, Guid vehicleId)> SeedVehicleCurrentlyInsideAsync(AppDbContext db)
     {
@@ -254,5 +254,27 @@ public class DashboardServiceTests
         var result = await CreateService(db).GetOccupancyAsync();
 
         Assert.Equal(0.0, result.OccupancyPercentage);
+    }
+
+    [Fact]
+    public async Task GetDashboardAsync_ReturnsAggregatedData()
+    {
+        var db = CreateInMemoryDb();
+        db.Settings.Add(new Settings { Name = "max_occupancy", Value = "100" });
+        await db.SaveChangesAsync();
+        await SeedVehicleCurrentlyInsideAsync(db);
+
+        var service = CreateService(db);
+        var result = await service.GetDashboardAsync();
+
+        Assert.Equal(1, result.CurrentOccupancy);
+        Assert.Equal(100, result.MaxOccupancy);
+        Assert.Equal(1, result.EntriesLastHour);
+        Assert.Equal(0, result.ExitsLastHour);
+        Assert.True(result.PeakHourEntries > 0);
+        Assert.NotNull(result.PeakEntryTime);
+        Assert.True(result.UpdatedAt > DateTime.MinValue);
+        Assert.NotNull(result.Accesses);
+        Assert.NotEmpty(result.Accesses);
     }
 }

--- a/Backend.Tests.Unit/Features/Dashboard/DashboardServiceTests.cs
+++ b/Backend.Tests.Unit/Features/Dashboard/DashboardServiceTests.cs
@@ -273,6 +273,7 @@ public class DashboardServiceTests
         Assert.Equal(0, result.ExitsLastHour);
         Assert.True(result.PeakHourEntries > 0);
         Assert.NotNull(result.PeakEntryTime);
+        Assert.Equal($"{DateTime.UtcNow.AddMinutes(-30).Hour:D2}:00", result.PeakEntryTime);
         Assert.True(result.UpdatedAt > DateTime.MinValue);
         Assert.NotNull(result.Accesses);
         Assert.NotEmpty(result.Accesses);


### PR DESCRIPTION
## O que mudou

Adiciona `GET /api/dashboard` — endpoint consolidado que retorna métricas, ocupação e acessos em uma única chamada.

Reformula o `DashboardService.GetDashboardAsync()` para reutilizar `GetMetricsAsync()` e `GetOccupancyAsync()` em vez de reimplementar a lógica.

### Por que

- Frontend precisa de um único endpoint para polling a cada 5s
- Evita duplicação de queries no banco
- Reaproveita os métodos existentes em vez de recriar a lógica

### Arquivos alterados

- `DashboardMetricsDto.cs` — adiciona `CurrentOccupancy`, `Accesses`, `UpdatedAt`; mantém `PeakHourEntries` (renomeado de `PeakEntryHour`)
- `DashboardService.cs` — `GetDashboardAsync()` reutiliza métodos existentes sequencialmente (EF Core não é thread-safe)
- `DashboardController.cs` — action `GET /api/dashboard`
- Testes unitários e de integração — cobertura para o novo endpoint + asserções para `PeakHourEntries`

### Notas

- Rebaseado em `main` (que já tem o PR #106 com `PeakHourEntries`)
- `PeakEntryHour` renomeado para `PeakHourEntries` para alinhar com PR #106 e issue #88

Closes #88