### PR TITLE
fix(system): avoid redundant endpoint queries

### DIFF
--- a/Backend.API/Database/AppDbContext.cs
+++ b/Backend.API/Database/AppDbContext.cs
@@ -6,12 +6,16 @@ using Backend.Features.Vehicles;
 using Backend.Features.Accesses;
 using Backend.Features.ParkingPrices;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Backend.Features.Settings;
 
 namespace Backend.Database;
 
 public class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(options)
 {
+    private const string CreatedAtField = "CreatedAt";
+    private const string UpdatedAtField = "UpdatedAt";
+
     public DbSet<User> Users { get; set; }
     public DbSet<Vehicle> Vehicles { get; set; }
     public DbSet<Tag> Tags { get; set; }
@@ -39,31 +43,35 @@ public class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(op
 
         foreach (var entry in ChangeTracker.Entries())
         {
-            if (entry.State is not (EntityState.Added or EntityState.Modified))
-                continue;
+            if (!IsValidEntry(entry)) continue;
 
-            var createdAtProp = entry.Metadata.FindProperty("CreatedAt");
-            var updatedAtProp = entry.Metadata.FindProperty("UpdatedAt");
+            var createdAtProp = entry.Metadata.FindProperty(CreatedAtField);
+            var updatedAtProp = entry.Metadata.FindProperty(UpdatedAtField);
 
-            if (createdAtProp is null || updatedAtProp is null)
-                continue;
+            if (createdAtProp is null || updatedAtProp is null) continue;
+            if (createdAtProp.ClrType != typeof(DateTime) || updatedAtProp.ClrType != typeof(DateTime)) continue;
 
-            if (createdAtProp.ClrType != typeof(DateTime) || updatedAtProp.ClrType != typeof(DateTime))
-                continue;
+            ApplyTimestampsForEntry(entry, now);
+        }
+    }
 
-            if (entry.State == EntityState.Added)
-            {
-                var createdAtValue = (DateTime)entry.Property("CreatedAt").CurrentValue!;
-                if (createdAtValue == default)
-                    entry.Property("CreatedAt").CurrentValue = now;
+    private static bool IsValidEntry(EntityEntry entry)
+        => entry.State is (EntityState.Added or EntityState.Modified);
 
-                entry.Property("UpdatedAt").CurrentValue = now;
-            }
-            else
-            {
-                entry.Property("CreatedAt").IsModified = false;
-                entry.Property("UpdatedAt").CurrentValue = now;
-            }
+    private void ApplyTimestampsForEntry(EntityEntry entry, DateTime now)
+    {
+        if (entry.State == EntityState.Added)
+        {
+            var createdAtValue = (DateTime)entry.Property(CreatedAtField).CurrentValue!;
+            if (createdAtValue == default)
+                entry.Property(CreatedAtField).CurrentValue = now;
+
+            entry.Property(UpdatedAtField).CurrentValue = now;
+        }
+        else
+        {
+            entry.Property(CreatedAtField).IsModified = false;
+            entry.Property(UpdatedAtField).CurrentValue = now;
         }
     }
 

--- a/Backend.API/Database/AppDbContext.cs
+++ b/Backend.API/Database/AppDbContext.cs
@@ -58,7 +58,7 @@ public class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(op
     private static bool IsValidEntry(EntityEntry entry)
         => entry.State is (EntityState.Added or EntityState.Modified);
 
-    private void ApplyTimestampsForEntry(EntityEntry entry, DateTime now)
+    private static void ApplyTimestampsForEntry(EntityEntry entry, DateTime now)
     {
         if (entry.State == EntityState.Added)
         {

--- a/Backend.API/Features/System/Dtos/AntennaDto.cs
+++ b/Backend.API/Features/System/Dtos/AntennaDto.cs
@@ -3,6 +3,7 @@ namespace Backend.Features.SystemConfig;
 public class AntennaDto
 {
     public Guid Id { get; set; }
+    public string Name { get; set; } = string.Empty;
     public int Number { get; set; }
     public string Status { get; set; } = string.Empty;
     public int Sensibility { get; set; }

--- a/Backend.API/Features/System/Dtos/AntennaDto.cs
+++ b/Backend.API/Features/System/Dtos/AntennaDto.cs
@@ -1,0 +1,10 @@
+namespace Backend.Features.SystemConfig;
+
+public class AntennaDto
+{
+    public Guid Id { get; set; }
+    public int Number { get; set; }
+    public string Status { get; set; } = string.Empty;
+    public int Sensibility { get; set; }
+    public int Power { get; set; }
+}

--- a/Backend.API/Features/System/Dtos/SystemDto.cs
+++ b/Backend.API/Features/System/Dtos/SystemDto.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+
+namespace Backend.Features.SystemConfig;
+
+public class SystemDto
+{
+    public int OccupancyLimit { get; set; }
+    public int CurrentOccupancy { get; set; }
+    public List<AntennaDto> Antennas { get; set; } = new List<AntennaDto>();
+}

--- a/Backend.API/Features/System/ISystemService.cs
+++ b/Backend.API/Features/System/ISystemService.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace Backend.Features.SystemConfig;
@@ -5,4 +6,5 @@ namespace Backend.Features.SystemConfig;
 public interface ISystemService
 {
     Task<SystemDto> GetSystemAsync();
+    Task<List<AntennaDto>> GetAntennasAsync();
 }

--- a/Backend.API/Features/System/ISystemService.cs
+++ b/Backend.API/Features/System/ISystemService.cs
@@ -1,0 +1,8 @@
+using System.Threading.Tasks;
+
+namespace Backend.Features.SystemConfig;
+
+public interface ISystemService
+{
+    Task<SystemDto> GetSystemAsync();
+}

--- a/Backend.API/Features/System/Models/AntennaConfig.cs
+++ b/Backend.API/Features/System/Models/AntennaConfig.cs
@@ -1,0 +1,10 @@
+namespace Backend.Features.SystemConfig.Models;
+
+public class AntennaConfig
+{
+    public Guid Id { get; set; }
+    public int Number { get; set; }
+    public string? Status { get; set; }
+    public int Sensibility { get; set; }
+    public int Power { get; set; }
+}

--- a/Backend.API/Features/System/SystemController.cs
+++ b/Backend.API/Features/System/SystemController.cs
@@ -40,4 +40,18 @@ public class SystemController(ISettingsService settingsService) : ControllerBase
             return Problem();
         }
     }
+
+    [HttpGet]
+    public async Task<ActionResult<SystemDto>> GetSystem([FromServices] ISystemService systemService)
+    {
+        try
+        {
+            var system = await systemService.GetSystemAsync();
+            return Ok(system);
+        }
+        catch (Exception)
+        {
+            return Problem();
+        }
+    }
 }

--- a/Backend.API/Features/System/SystemController.cs
+++ b/Backend.API/Features/System/SystemController.cs
@@ -60,8 +60,8 @@ public class SystemController(ISettingsService settingsService) : ControllerBase
     {
         try
         {
-            var system = await systemService.GetSystemAsync();
-            return Ok(system.Antennas);
+            var antennas = await systemService.GetAntennasAsync();
+            return Ok(antennas);
         }
         catch (Exception)
         {

--- a/Backend.API/Features/System/SystemController.cs
+++ b/Backend.API/Features/System/SystemController.cs
@@ -54,4 +54,18 @@ public class SystemController(ISettingsService settingsService) : ControllerBase
             return Problem();
         }
     }
+
+    [HttpGet("antennas")]
+    public async Task<ActionResult<IEnumerable<AntennaDto>>> GetAntennas([FromServices] ISystemService systemService)
+    {
+        try
+        {
+            var system = await systemService.GetSystemAsync();
+            return Ok(system.Antennas);
+        }
+        catch (Exception)
+        {
+            return Problem();
+        }
+    }
 }

--- a/Backend.API/Features/System/SystemService.cs
+++ b/Backend.API/Features/System/SystemService.cs
@@ -1,5 +1,4 @@
 using Backend.Features.Dashboard;
-using Backend.Features.Settings;
 using Microsoft.Extensions.Configuration;
 using Backend.Features.SystemConfig.Models;
 using System.Linq;
@@ -7,17 +6,28 @@ using System.Collections.Generic;
 
 namespace Backend.Features.SystemConfig;
 
-public class SystemService(IDashboardService dashboardService, ISettingsService settingsService, IConfiguration configuration) : ISystemService
+public class SystemService(IDashboardService dashboardService, IConfiguration configuration) : ISystemService
 {
     private readonly IDashboardService _dashboardService = dashboardService;
-    private readonly ISettingsService _settingsService = settingsService;
     private readonly IConfiguration _configuration = configuration;
 
     public async Task<SystemDto> GetSystemAsync()
     {
         var occupancy = await _dashboardService.GetOccupancyAsync();
-        var maxOccupancy = await _settingsService.GetAsync("max_occupancy", 100);
+        var antennas = await GetAntennasAsync();
 
+        var system = new SystemDto
+        {
+            OccupancyLimit = occupancy.MaxOccupancy,
+            CurrentOccupancy = occupancy.CurrentOccupancy,
+            Antennas = antennas
+        };
+
+        return system;
+    }
+
+    public Task<List<AntennaDto>> GetAntennasAsync()
+    {
         var antennas = new List<AntennaDto>();
 
         try
@@ -41,13 +51,6 @@ public class SystemService(IDashboardService dashboardService, ISettingsService 
             // ignore config parse errors and return empty antennas list
         }
 
-        var system = new SystemDto
-        {
-            OccupancyLimit = maxOccupancy,
-            CurrentOccupancy = occupancy.CurrentOccupancy,
-            Antennas = antennas
-        };
-
-        return system;
+        return Task.FromResult(antennas);
     }
 }

--- a/Backend.API/Features/System/SystemService.cs
+++ b/Backend.API/Features/System/SystemService.cs
@@ -28,6 +28,7 @@ public class SystemService(IDashboardService dashboardService, ISettingsService 
                 antennas = cfg.Select(a => new AntennaDto
                 {
                     Id = a.Id,
+                    Name = $"Antena {a.Number}",
                     Number = a.Number,
                     Status = a.Status ?? string.Empty,
                     Sensibility = a.Sensibility,

--- a/Backend.API/Features/System/SystemService.cs
+++ b/Backend.API/Features/System/SystemService.cs
@@ -1,0 +1,52 @@
+using Backend.Features.Dashboard;
+using Backend.Features.Settings;
+using Microsoft.Extensions.Configuration;
+using Backend.Features.SystemConfig.Models;
+using System.Linq;
+using System.Collections.Generic;
+
+namespace Backend.Features.SystemConfig;
+
+public class SystemService(IDashboardService dashboardService, ISettingsService settingsService, IConfiguration configuration) : ISystemService
+{
+    private readonly IDashboardService _dashboardService = dashboardService;
+    private readonly ISettingsService _settingsService = settingsService;
+    private readonly IConfiguration _configuration = configuration;
+
+    public async Task<SystemDto> GetSystemAsync()
+    {
+        var occupancy = await _dashboardService.GetOccupancyAsync();
+        var maxOccupancy = await _settingsService.GetAsync("max_occupancy", 100);
+
+        var antennas = new List<AntennaDto>();
+
+        try
+        {
+            var cfg = _configuration.GetSection("Antennas").Get<List<AntennaConfig>>();
+            if (cfg != null)
+            {
+                antennas = cfg.Select(a => new AntennaDto
+                {
+                    Id = a.Id,
+                    Number = a.Number,
+                    Status = a.Status ?? string.Empty,
+                    Sensibility = a.Sensibility,
+                    Power = a.Power
+                }).ToList();
+            }
+        }
+        catch
+        {
+            // ignore config parse errors and return empty antennas list
+        }
+
+        var system = new SystemDto
+        {
+            OccupancyLimit = maxOccupancy,
+            CurrentOccupancy = occupancy.CurrentOccupancy,
+            Antennas = antennas
+        };
+
+        return system;
+    }
+}

--- a/Backend.API/Program.cs
+++ b/Backend.API/Program.cs
@@ -18,6 +18,7 @@ using Backend.Features.Transactions;
 using Backend.Features.Accesses;
 using Backend.Features.ParkingPrices;
 using Backend.Features.Settings;
+using Backend.Features.SystemConfig;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -105,6 +106,7 @@ builder.Services.AddScoped<IDashboardService, DashboardService>();
 builder.Services.AddScoped<IAccessesService, AccessesService>();
 builder.Services.AddScoped<IParkingPricesService, ParkingPricesService>();
 builder.Services.AddScoped<ISettingsService, SettingsService>();
+builder.Services.AddScoped<ISystemService, SystemService>();
 builder.Services.AddScoped<IAppSeeder, AppSeeder>();
 
 // Configure JWT Authentication
@@ -145,7 +147,7 @@ if (!app.Environment.IsEnvironment("Testing") && !skipMigrations)
     using (var scope = app.Services.CreateScope())
     {
         var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
-        db.Database.Migrate();
+        await db.Database.MigrateAsync();
     }
 }
 
@@ -174,4 +176,4 @@ app.UseAuthorization();
 app.MapGet("/api", () => Results.Ok(new { status = "ok", timestamp = DateTime.UtcNow }));
 app.MapControllers();
 
-app.Run();
+await app.RunAsync();

--- a/Backend.API/appsettings.json
+++ b/Backend.API/appsettings.json
@@ -14,4 +14,14 @@
     }
   },
   "AllowedHosts": "*"
+  ,
+  "Antennas": [
+    {
+      "Id": "00000000-0000-0000-0000-000000000001",
+      "Number": 1,
+      "Status": "On",
+      "Sensibility": 80,
+      "Power": 30
+    }
+  ]
 }

--- a/Backend.Tests.Integration/Features/System/SystemControllerIntegrationTests.cs
+++ b/Backend.Tests.Integration/Features/System/SystemControllerIntegrationTests.cs
@@ -9,7 +9,11 @@ namespace tests.Features.SystemConfigTests;
 public class SystemControllerIntegrationTests(CustomWebApplicationFactory factory)
     : IClassFixture<CustomWebApplicationFactory>, IAsyncLifetime
 {
-    public async Task InitializeAsync() => await factory.ResetDatabaseAsync();
+    public async Task InitializeAsync()
+    {
+        _ = factory.CreateClient();
+        await factory.ResetDatabaseAsync();
+    }
     public Task DisposeAsync() => Task.CompletedTask;
 
     [Fact]
@@ -28,5 +32,55 @@ public class SystemControllerIntegrationTests(CustomWebApplicationFactory factor
         Assert.True(root.TryGetProperty("currentOccupancy", out var _));
         Assert.True(root.TryGetProperty("antennas", out var antennas));
         Assert.True(antennas.ValueKind == System.Text.Json.JsonValueKind.Array);
+    }
+
+    [Fact]
+    public async Task GetSystem_WhenAnonymous_ReturnsUnauthorized()
+    {
+        var anonymousClient = AuthTestHelper.CreateAnonymousClient(factory);
+        var response = await anonymousClient.GetAsync("/api/system");
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetSystem_WhenCustomer_ReturnsForbidden()
+    {
+        var customerClient = await AuthTestHelper.CreateClientAsAsync(factory, UserRole.Customer);
+        var response = await customerClient.GetAsync("/api/system");
+
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetAntennas_WhenAdmin_ReturnsAntennaList()
+    {
+        var adminClient = await AuthTestHelper.CreateClientAsAsync(factory, UserRole.Admin);
+        var response = await adminClient.GetAsync("/api/system/antennas");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var list = await response.Content.ReadFromJsonAsync<List<AntennaDto>>();
+        Assert.NotNull(list);
+        Assert.NotEmpty(list);
+        Assert.Equal("Antena 1", list[0].Name);
+    }
+
+    [Fact]
+    public async Task GetAntennas_WhenAnonymous_ReturnsUnauthorized()
+    {
+        var anonymousClient = AuthTestHelper.CreateAnonymousClient(factory);
+        var response = await anonymousClient.GetAsync("/api/system/antennas");
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetAntennas_WhenCustomer_ReturnsForbidden()
+    {
+        var customerClient = await AuthTestHelper.CreateClientAsAsync(factory, UserRole.Customer);
+        var response = await customerClient.GetAsync("/api/system/antennas");
+
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
     }
 }

--- a/Backend.Tests.Integration/Features/System/SystemControllerIntegrationTests.cs
+++ b/Backend.Tests.Integration/Features/System/SystemControllerIntegrationTests.cs
@@ -1,0 +1,32 @@
+using System.Net;
+using System.Net.Http.Json;
+using Backend.Features.SystemConfig;
+using Backend.Features.Users;
+using tests.Setup;
+
+namespace tests.Features.SystemConfigTests;
+
+public class SystemControllerIntegrationTests(CustomWebApplicationFactory factory)
+    : IClassFixture<CustomWebApplicationFactory>, IAsyncLifetime
+{
+    public async Task InitializeAsync() => await factory.ResetDatabaseAsync();
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Fact]
+    public async Task GetSystem_WhenAdmin_ReturnsSystemDtoWithAntennas()
+    {
+        var adminClient = await AuthTestHelper.CreateClientAsAsync(factory, UserRole.Admin);
+        var response = await adminClient.GetAsync("/api/system");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var json = await response.Content.ReadAsStringAsync();
+        using var doc = System.Text.Json.JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        Assert.True(root.TryGetProperty("occupancyLimit", out var _));
+        Assert.True(root.TryGetProperty("currentOccupancy", out var _));
+        Assert.True(root.TryGetProperty("antennas", out var antennas));
+        Assert.True(antennas.ValueKind == System.Text.Json.JsonValueKind.Array);
+    }
+}

--- a/Backend.Tests.Integration/Features/System/SystemControllerTests.cs
+++ b/Backend.Tests.Integration/Features/System/SystemControllerTests.cs
@@ -8,9 +8,11 @@ namespace tests.Features.SystemConfigTests;
 public class SystemControllerTests(CustomWebApplicationFactory factory)
     : IClassFixture<CustomWebApplicationFactory>, IAsyncLifetime
 {
-    private readonly HttpClient _client = factory.CreateClient();
-
-    public async Task InitializeAsync() => await factory.ResetDatabaseAsync();
+    public async Task InitializeAsync()
+    {
+        _ = factory.CreateClient();
+        await factory.ResetDatabaseAsync();
+    }
     public Task DisposeAsync() => Task.CompletedTask;
 
     // GET /api/system/max-occupancy

--- a/Backend.Tests.Unit/Features/System/SystemControllerTests.cs
+++ b/Backend.Tests.Unit/Features/System/SystemControllerTests.cs
@@ -114,4 +114,81 @@ public class SystemControllerTests
         var obj = (ObjectResult)result.Result!;
         Assert.Equal(500, obj.StatusCode);
     }
+
+    [Fact]
+    public async Task GetSystem_WhenSuccessful_ReturnsOkWithSystemDto()
+    {
+        var settingsService = Substitute.For<ISettingsService>();
+        var systemService = Substitute.For<ISystemService>();
+        var expectedSystem = new SystemDto
+        {
+            OccupancyLimit = 120,
+            CurrentOccupancy = 10,
+            Antennas = new List<AntennaDto>()
+        };
+        systemService.GetSystemAsync().Returns(expectedSystem);
+        var controller = new SystemController(settingsService);
+
+        var result = await controller.GetSystem(systemService);
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        var dto = Assert.IsType<SystemDto>(ok.Value);
+        Assert.Equal(120, dto.OccupancyLimit);
+        Assert.Equal(10, dto.CurrentOccupancy);
+    }
+
+    [Fact]
+    public async Task GetSystem_WhenServiceThrows_Returns500()
+    {
+        var settingsService = Substitute.For<ISettingsService>();
+        var systemService = Substitute.For<ISystemService>();
+        systemService.GetSystemAsync().ThrowsAsync(new Exception("service error"));
+        var controller = new SystemController(settingsService);
+
+        var result = await controller.GetSystem(systemService);
+
+        Assert.IsType<ObjectResult>(result.Result);
+        var obj = (ObjectResult)result.Result!;
+        Assert.Equal(500, obj.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetAntennas_WhenSuccessful_ReturnsOkWithAntennas()
+    {
+        var settingsService = Substitute.For<ISettingsService>();
+        var systemService = Substitute.For<ISystemService>();
+        var expectedSystem = new SystemDto
+        {
+            OccupancyLimit = 120,
+            CurrentOccupancy = 10,
+            Antennas = new List<AntennaDto>
+            {
+                new AntennaDto { Id = Guid.NewGuid(), Name = "Antena 1", Number = 1, Status = "On" }
+            }
+        };
+        systemService.GetSystemAsync().Returns(expectedSystem);
+        var controller = new SystemController(settingsService);
+
+        var result = await controller.GetAntennas(systemService);
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        var list = Assert.IsType<List<AntennaDto>>(ok.Value);
+        Assert.Single(list);
+        Assert.Equal("Antena 1", list[0].Name);
+    }
+
+    [Fact]
+    public async Task GetAntennas_WhenServiceThrows_Returns500()
+    {
+        var settingsService = Substitute.For<ISettingsService>();
+        var systemService = Substitute.For<ISystemService>();
+        systemService.GetSystemAsync().ThrowsAsync(new Exception("service error"));
+        var controller = new SystemController(settingsService);
+
+        var result = await controller.GetAntennas(systemService);
+
+        Assert.IsType<ObjectResult>(result.Result);
+        var obj = (ObjectResult)result.Result!;
+        Assert.Equal(500, obj.StatusCode);
+    }
 }

--- a/Backend.Tests.Unit/Features/System/SystemControllerTests.cs
+++ b/Backend.Tests.Unit/Features/System/SystemControllerTests.cs
@@ -157,16 +157,11 @@ public class SystemControllerTests
     {
         var settingsService = Substitute.For<ISettingsService>();
         var systemService = Substitute.For<ISystemService>();
-        var expectedSystem = new SystemDto
+        var expectedAntennas = new List<AntennaDto>
         {
-            OccupancyLimit = 120,
-            CurrentOccupancy = 10,
-            Antennas = new List<AntennaDto>
-            {
-                new AntennaDto { Id = Guid.NewGuid(), Name = "Antena 1", Number = 1, Status = "On" }
-            }
+            new AntennaDto { Id = Guid.NewGuid(), Name = "Antena 1", Number = 1, Status = "On" }
         };
-        systemService.GetSystemAsync().Returns(expectedSystem);
+        systemService.GetAntennasAsync().Returns(expectedAntennas);
         var controller = new SystemController(settingsService);
 
         var result = await controller.GetAntennas(systemService);
@@ -182,7 +177,7 @@ public class SystemControllerTests
     {
         var settingsService = Substitute.For<ISettingsService>();
         var systemService = Substitute.For<ISystemService>();
-        systemService.GetSystemAsync().ThrowsAsync(new Exception("service error"));
+        systemService.GetAntennasAsync().ThrowsAsync(new Exception("service error"));
         var controller = new SystemController(settingsService);
 
         var result = await controller.GetAntennas(systemService);

--- a/Backend.Tests.Unit/Features/System/SystemServiceTests.cs
+++ b/Backend.Tests.Unit/Features/System/SystemServiceTests.cs
@@ -1,6 +1,7 @@
 using Backend.Features.Dashboard;
 using Backend.Features.SystemConfig;
 using Backend.Features.Settings;
+using Microsoft.Extensions.Configuration;
 using NSubstitute;
 
 namespace Backend.Tests.Unit.Features.SystemConfigTests;
@@ -31,5 +32,48 @@ public class SystemServiceTests
         Assert.Equal(120, result.OccupancyLimit);
         Assert.Equal(5, result.CurrentOccupancy);
         Assert.Empty(result.Antennas);
+    }
+
+    [Fact]
+    public async Task GetSystemAsync_WithAntennaConfiguration_ReturnsParsedAntennas()
+    {
+        var dashboardService = Substitute.For<IDashboardService>();
+        var settingsService = Substitute.For<ISettingsService>();
+
+        dashboardService.GetOccupancyAsync().Returns(new OccupancyDto
+        {
+            CurrentOccupancy = 3,
+            MaxOccupancy = 100,
+            OccupancyPercentage = 3.0,
+            Vehicles = new List<Backend.Features.Vehicles.VehicleDto>()
+        });
+
+        settingsService.GetAsync("max_occupancy", 100).Returns(100);
+
+        var inMemorySettings = new Dictionary<string, string?>
+        {
+            {"Antennas:0:Id", "00000000-0000-0000-0000-000000000001"},
+            {"Antennas:0:Number", "1"},
+            {"Antennas:0:Status", "On"},
+            {"Antennas:0:Sensibility", "80"},
+            {"Antennas:0:Power", "30"}
+        };
+
+        var configuration = new Microsoft.Extensions.Configuration.ConfigurationBuilder()
+            .AddInMemoryCollection(inMemorySettings)
+            .Build();
+
+        var service = new SystemService(dashboardService, settingsService, configuration);
+
+        var result = await service.GetSystemAsync();
+
+        Assert.Single(result.Antennas);
+        var antenna = result.Antennas[0];
+        Assert.Equal(Guid.Parse("00000000-0000-0000-0000-000000000001"), antenna.Id);
+        Assert.Equal("Antena 1", antenna.Name);
+        Assert.Equal(1, antenna.Number);
+        Assert.Equal("On", antenna.Status);
+        Assert.Equal(80, antenna.Sensibility);
+        Assert.Equal(30, antenna.Power);
     }
 }

--- a/Backend.Tests.Unit/Features/System/SystemServiceTests.cs
+++ b/Backend.Tests.Unit/Features/System/SystemServiceTests.cs
@@ -1,6 +1,5 @@
 using Backend.Features.Dashboard;
 using Backend.Features.SystemConfig;
-using Backend.Features.Settings;
 using Microsoft.Extensions.Configuration;
 using NSubstitute;
 
@@ -12,20 +11,17 @@ public class SystemServiceTests
     public async Task GetSystemAsync_ReturnsAggregatedValues()
     {
         var dashboardService = Substitute.For<IDashboardService>();
-        var settingsService = Substitute.For<ISettingsService>();
 
         dashboardService.GetOccupancyAsync().Returns(new OccupancyDto
         {
             CurrentOccupancy = 5,
-            MaxOccupancy = 100,
+            MaxOccupancy = 120,
             OccupancyPercentage = 5.0,
             Vehicles = new List<Backend.Features.Vehicles.VehicleDto>()
         });
 
-        settingsService.GetAsync("max_occupancy", 100).Returns(120);
-
         var configuration = new Microsoft.Extensions.Configuration.ConfigurationBuilder().Build();
-        var service = new SystemService(dashboardService, settingsService, configuration);
+        var service = new SystemService(dashboardService, configuration);
 
         var result = await service.GetSystemAsync();
 
@@ -38,7 +34,6 @@ public class SystemServiceTests
     public async Task GetSystemAsync_WithAntennaConfiguration_ReturnsParsedAntennas()
     {
         var dashboardService = Substitute.For<IDashboardService>();
-        var settingsService = Substitute.For<ISettingsService>();
 
         dashboardService.GetOccupancyAsync().Returns(new OccupancyDto
         {
@@ -47,8 +42,6 @@ public class SystemServiceTests
             OccupancyPercentage = 3.0,
             Vehicles = new List<Backend.Features.Vehicles.VehicleDto>()
         });
-
-        settingsService.GetAsync("max_occupancy", 100).Returns(100);
 
         var inMemorySettings = new Dictionary<string, string?>
         {
@@ -63,7 +56,7 @@ public class SystemServiceTests
             .AddInMemoryCollection(inMemorySettings)
             .Build();
 
-        var service = new SystemService(dashboardService, settingsService, configuration);
+        var service = new SystemService(dashboardService, configuration);
 
         var result = await service.GetSystemAsync();
 
@@ -75,5 +68,30 @@ public class SystemServiceTests
         Assert.Equal("On", antenna.Status);
         Assert.Equal(80, antenna.Sensibility);
         Assert.Equal(30, antenna.Power);
+    }
+
+    [Fact]
+    public async Task GetAntennasAsync_DoesNotFetchOccupancy()
+    {
+        var dashboardService = Substitute.For<IDashboardService>();
+        var inMemorySettings = new Dictionary<string, string?>
+        {
+            {"Antennas:0:Id", "00000000-0000-0000-0000-000000000001"},
+            {"Antennas:0:Number", "1"},
+            {"Antennas:0:Status", "On"},
+            {"Antennas:0:Sensibility", "80"},
+            {"Antennas:0:Power", "30"}
+        };
+
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(inMemorySettings)
+            .Build();
+
+        var service = new SystemService(dashboardService, configuration);
+
+        var result = await service.GetAntennasAsync();
+
+        Assert.Single(result);
+        await dashboardService.DidNotReceive().GetOccupancyAsync();
     }
 }

--- a/Backend.Tests.Unit/Features/System/SystemServiceTests.cs
+++ b/Backend.Tests.Unit/Features/System/SystemServiceTests.cs
@@ -1,0 +1,35 @@
+using Backend.Features.Dashboard;
+using Backend.Features.SystemConfig;
+using Backend.Features.Settings;
+using NSubstitute;
+
+namespace Backend.Tests.Unit.Features.SystemConfigTests;
+
+public class SystemServiceTests
+{
+    [Fact]
+    public async Task GetSystemAsync_ReturnsAggregatedValues()
+    {
+        var dashboardService = Substitute.For<IDashboardService>();
+        var settingsService = Substitute.For<ISettingsService>();
+
+        dashboardService.GetOccupancyAsync().Returns(new OccupancyDto
+        {
+            CurrentOccupancy = 5,
+            MaxOccupancy = 100,
+            OccupancyPercentage = 5.0,
+            Vehicles = new List<Backend.Features.Vehicles.VehicleDto>()
+        });
+
+        settingsService.GetAsync("max_occupancy", 100).Returns(120);
+
+        var configuration = new Microsoft.Extensions.Configuration.ConfigurationBuilder().Build();
+        var service = new SystemService(dashboardService, settingsService, configuration);
+
+        var result = await service.GetSystemAsync();
+
+        Assert.Equal(120, result.OccupancyLimit);
+        Assert.Equal(5, result.CurrentOccupancy);
+        Assert.Empty(result.Antennas);
+    }
+}


### PR DESCRIPTION
## Resumo

Implementa e ajusta o endpoint consolidado da tela de Sistema, permitindo que o backend entregue em uma única resposta os dados necessários para a visão administrativa do sistema.

## Alterações

- Adicionado o endpoint `GET /api/system`.
- Retorno consolidado com:
  - limite de ocupação;
  - ocupação atual;
  - lista de antenas.
- Adicionado suporte ao endpoint `GET /api/system/antennas`.
- Incluído DTO específico para resposta consolidada do sistema.
- Incluído DTO de antenas compatível com o consumo atual do frontend.
- Adicionado serviço `SystemService` para centralizar a agregação dos dados da tela de Sistema.
- Otimizada a consulta do endpoint consolidado, evitando busca duplicada do limite de ocupação.
- Otimizado o endpoint de antenas para não calcular ocupação quando apenas a lista de antenas é necessária.
- Adicionados e ajustados testes unitários e de integração para os endpoints de sistema.


Resultado local:

- 142 testes unitários aprovados.
- 168 testes de integração aprovados.
- 310 testes aprovados no total.