### PR TITLE
feat: estende GET /api/dashboard/metrics com PeakHourEntries

### DIFF
--- a/Backend.API/Features/Dashboard/DashboardService.cs
+++ b/Backend.API/Features/Dashboard/DashboardService.cs
@@ -56,11 +56,12 @@ public class DashboardService(AppDbContext db, ISettingsService settingsService)
         var exitsLastHour = await _db.Accesses
             .CountAsync(a => a.Type == AccessType.Exit && a.Timestamp >= oneHourAgo);
 
-        var peakEntryTime = await _db.Accesses
+        var peakEntry = await _db.Accesses
+            .AsNoTracking()
             .Where(a => a.Type == AccessType.Entry && a.Timestamp >= twentyFourHoursAgo)
             .GroupBy(a => a.Timestamp.Hour)
             .OrderByDescending(g => g.Count())
-            .Select(g => g.Key)
+            .Select(g => new { Hour = g.Key, Count = g.Count() })
             .FirstOrDefaultAsync();
 
         var maxOccupancy = await _settingsService.GetAsync("max_occupancy", 100);
@@ -69,9 +70,10 @@ public class DashboardService(AppDbContext db, ISettingsService settingsService)
         {
             EntriesLastHour = entriesLastHour,
             ExitsLastHour = exitsLastHour,
-            PeakEntryTime = peakEntryTime == 0 && entriesLastHour == 0
-                ? null
-                : $"{peakEntryTime:D2}:00",
+            PeakEntryTime = peakEntry != null
+                ? $"{peakEntry.Hour:D2}:00"
+                : null,
+            PeakHourEntries = peakEntry?.Count ?? 0,
             MaxOccupancy = maxOccupancy
         };
     }

--- a/Backend.API/Features/Dashboard/Dtos/DashboardMetricsDto.cs
+++ b/Backend.API/Features/Dashboard/Dtos/DashboardMetricsDto.cs
@@ -5,5 +5,6 @@ public class DashboardMetricsDto
     public int EntriesLastHour { get; set; }
     public int ExitsLastHour { get; set; }
     public string? PeakEntryTime { get; set; }
+    public int PeakHourEntries { get; set; }
     public int MaxOccupancy { get; set; }
 }

--- a/Backend.Tests.Integration/Features/Dashboard/DashboardControllerTests.cs
+++ b/Backend.Tests.Integration/Features/Dashboard/DashboardControllerTests.cs
@@ -193,6 +193,7 @@ public class DashboardControllerTests(CustomWebApplicationFactory factory)
         Assert.Equal(0, metrics.EntriesLastHour);
         Assert.Equal(0, metrics.ExitsLastHour);
         Assert.Null(metrics.PeakEntryTime);
+        Assert.Equal(0, metrics.PeakHourEntries);
     }
 
     [Fact]

--- a/Backend.Tests.Unit/Features/Dashboard/DashboardControllerTests.cs
+++ b/Backend.Tests.Unit/Features/Dashboard/DashboardControllerTests.cs
@@ -98,6 +98,7 @@ public class DashboardControllerTests
         var expected = new DashboardMetricsDto
         {
             EntriesLastHour = 5,
+            PeakHourEntries = 5,
             ExitsLastHour = 3,
             PeakEntryTime = "14:00"
         };
@@ -135,7 +136,8 @@ public class DashboardControllerTests
         {
             EntriesLastHour = 0,
             ExitsLastHour = 0,
-            PeakEntryTime = null
+            PeakEntryTime = null,
+            PeakHourEntries = 0
         };
 
         var service = Substitute.For<IDashboardService>();
@@ -159,6 +161,7 @@ public class DashboardControllerTests
             EntriesLastHour = 0,
             ExitsLastHour = 0,
             PeakEntryTime = null,
+            PeakHourEntries = 0,
             MaxOccupancy = 150
         };
 

--- a/Backend.Tests.Unit/Features/Dashboard/DashboardServiceTests.cs
+++ b/Backend.Tests.Unit/Features/Dashboard/DashboardServiceTests.cs
@@ -39,6 +39,7 @@ public class DashboardServiceTests
         var result = await service.GetMetricsAsync();
 
         Assert.Equal(0, result.EntriesLastHour);
+        Assert.Equal(0, result.PeakHourEntries);
         Assert.Equal(0, result.ExitsLastHour);
         Assert.Null(result.PeakEntryTime);
     }
@@ -95,6 +96,7 @@ public class DashboardServiceTests
 
         Assert.NotNull(result.PeakEntryTime);
         Assert.Equal($"{peakHour.Hour:D2}:00", result.PeakEntryTime);
+        Assert.Equal(3, result.PeakHourEntries);
     }
 
     [Fact]
@@ -112,6 +114,7 @@ public class DashboardServiceTests
 
         Assert.Equal(0, result.EntriesLastHour);
         Assert.Equal(2, result.ExitsLastHour);
+        Assert.Equal(0, result.PeakHourEntries);
     }
 
     [Fact]
@@ -128,6 +131,7 @@ public class DashboardServiceTests
         var result = await service.GetMetricsAsync();
 
         Assert.Null(result.PeakEntryTime);
+        Assert.Equal(0, result.PeakHourEntries);
     }
 
     [Fact]


### PR DESCRIPTION
## O que mudou

Em vez de criar um endpoint separado, estendi o endpoint de metrics existente para incluir a contagem de entradas no horário de pico (PeakHourEntries).

## Por que

- O endpoint separado nao era consumido pelo frontend
- O endpoint de metrics ja calculava o horario de pico, so faltava o numero de entradas
- Menos endpoints, menos queries no banco, menos codigo para manter

## Arquivos alterados

- DashboardMetricsDto.cs - nova propriedade PeakHourEntries
- DashboardService.cs - query captura hora e contagem
- Testes unitarios e de integracao - assercoes para o novo campo

Closes #87